### PR TITLE
Enable basic Linux compatibility

### DIFF
--- a/SourceCode/AgLibrary.Tests/Settings/XmlSettingsHandlerTests.cs
+++ b/SourceCode/AgLibrary.Tests/Settings/XmlSettingsHandlerTests.cs
@@ -37,7 +37,7 @@ namespace AgLibrary.Tests.Settings
         public void LoadXMLFile_ShouldReturnMissingFile()
         {
             // Arrange
-            var filePath = @"C:\Path\To\Nonexisting\Settings.xml";
+            var filePath = Path.Combine(Path.GetTempPath(), "Nonexisting", "Settings.xml");
 
             // Act
             var loadResult = XmlSettingsHandler.LoadXMLFile(filePath, null);

--- a/SourceCode/GPS/Forms/Controls.Designer.cs
+++ b/SourceCode/GPS/Forms/Controls.Designer.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
+using System.Runtime.InteropServices;
 using AgLibrary.Logging;
 using AgOpenGPS.Core.Models;
 using AgOpenGPS.Core.Translations;
@@ -2178,8 +2179,19 @@ namespace AgOpenGPS
                 //save new copy of kml with selected flag and view in GoogleEarth
                 FileSaveSingleFlagKML(flagNumberPicked);
 
-                //Process.Start(@"C:\Program Files (x86)\Google\Google Earth\client\googleearth", workingDirectory + currentFieldDirectory + "\\Flags.KML");
-                Process.Start(Path.Combine(RegistrySettings.fieldsDirectory, currentFieldDirectory, "Flag.KML"));
+                var kmlPath = Path.Combine(RegistrySettings.fieldsDirectory, currentFieldDirectory, "Flag.KML");
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    Process.Start(new ProcessStartInfo(kmlPath) { UseShellExecute = true });
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    Process.Start("xdg-open", kmlPath);
+                }
+                else
+                {
+                    Process.Start(kmlPath);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Open KML flags using OS-appropriate viewers on Windows and Linux
- Use temp directory path when testing missing XML settings file for cross-platform compatibility

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c04b3ee268832c939ca644b0b23da5