### PR TITLE
Enable basic Linux build

### DIFF
--- a/SourceCode/AgDiag/AgDiag.csproj
+++ b/SourceCode/AgDiag/AgDiag.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <OutputPath>..\..\AgOpenGPS\</OutputPath>
     <ApplicationIcon>AgDiag.ico</ApplicationIcon>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
@@ -17,13 +16,13 @@
     <DebugType>none</DebugType>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Configuration" />
-  </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
-  </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
+    </ItemGroup>
 
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/SourceCode/AgIO/Source/AgIO.csproj
+++ b/SourceCode/AgIO/Source/AgIO.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <OutputPath>..\..\..\AgOpenGPS\</OutputPath>
     <ApplicationIcon>AgIO_ico.ico</ApplicationIcon>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
@@ -22,7 +21,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\References\RepeatButtonControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Configuration" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
@@ -31,9 +29,10 @@
     <ProjectReference Include="..\..\Keypad\Keypad.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
-  </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
+      <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    </ItemGroup>
 
   <ItemGroup>
     <Compile Update="Forms\Controls.Designer.cs">

--- a/SourceCode/AgLibrary/AgLibrary.csproj
+++ b/SourceCode/AgLibrary/AgLibrary.csproj
@@ -1,13 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-  </ItemGroup>
-
 </Project>

--- a/SourceCode/AgOpenGPS.ConsoleApp/AgOpenGPS.ConsoleApp.csproj
+++ b/SourceCode/AgOpenGPS.ConsoleApp/AgOpenGPS.ConsoleApp.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AgOpenGPS.Core\AgOpenGPS.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/SourceCode/AgOpenGPS.ConsoleApp/Program.cs
+++ b/SourceCode/AgOpenGPS.ConsoleApp/Program.cs
@@ -1,0 +1,13 @@
+using System;
+using AgOpenGPS.Core;
+
+namespace AgOpenGPS.ConsoleApp
+{
+    internal static class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine($"Loaded AgOpenGPS.Core assembly: {typeof(ApplicationCore).Assembly.FullName}");
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
+++ b/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -9,10 +9,6 @@
   <ItemGroup>
     <PackageReference Include="OpenTK" Version="3.3.3" />
     <ProjectReference Include="..\AgLibrary\AgLibrary.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SourceCode/AgOpenGPS.Core/Utils/Visibility.cs
+++ b/SourceCode/AgOpenGPS.Core/Utils/Visibility.cs
@@ -1,0 +1,11 @@
+namespace AgOpenGPS.Core
+{
+    /// <summary>
+    /// Minimal replacement for WPF's Visibility enumeration to allow cross-platform builds.
+    /// </summary>
+    public enum Visibility
+    {
+        Visible,
+        Collapsed
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/FieldTableViewModel.cs
+++ b/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/FieldTableViewModel.cs
@@ -2,7 +2,6 @@
 using AgOpenGPS.Core.Models;
 using AgOpenGPS.Core.Streamers;
 using System.Collections.ObjectModel;
-using System.Windows;
 using System.Windows.Input;
 
 namespace AgOpenGPS.Core.ViewModels

--- a/SourceCode/AgOpenGPS.sln
+++ b/SourceCode/AgOpenGPS.sln
@@ -32,6 +32,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.WpfViews", "AgOpe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgDiag", "AgDiag\AgDiag.csproj", "{8AE86C22-D6EA-46D3-A053-C10B15EDEC8A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.ConsoleApp", "AgOpenGPS.ConsoleApp\AgOpenGPS.ConsoleApp.csproj", "{1EB6FBF7-9DE9-4742-A4AD-41E21FD79AC5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,10 @@ Global
 		{8AE86C22-D6EA-46D3-A053-C10B15EDEC8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8AE86C22-D6EA-46D3-A053-C10B15EDEC8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8AE86C22-D6EA-46D3-A053-C10B15EDEC8A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {1EB6FBF7-9DE9-4742-A4AD-41E21FD79AC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1EB6FBF7-9DE9-4742-A4AD-41E21FD79AC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1EB6FBF7-9DE9-4742-A4AD-41E21FD79AC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1EB6FBF7-9DE9-4742-A4AD-41E21FD79AC5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <OutputPath>..\..\AgOpenGPS\</OutputPath>
     <ApplicationIcon>AOG.ico</ApplicationIcon>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
@@ -28,9 +27,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\References\RepeatButtonControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Management" />
-    <Reference Include="System.Windows.Forms.DataVisualization" />
   </ItemGroup>
 
   <ItemGroup>
@@ -53,6 +49,9 @@
     <PackageReference Include="System.ValueTuple" Version="4.6.1" />
     <PackageReference Include="WebEye.Controls.WinForms.WebCameraControl" Version="1.0.2" />
     <PackageReference Include="WinFormsMapControl" Version="1.1.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Management" Version="6.0.0" />
+    <PackageReference Include="System.Windows.Forms.DataVisualization" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SourceCode/GPS_Out/Source/GPS_Out.csproj
+++ b/SourceCode/GPS_Out/Source/GPS_Out.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <OutputPath>..\..\..\AgOpenGPS\</OutputPath>
     <ApplicationIcon>satellite.ico</ApplicationIcon>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>

--- a/SourceCode/Keypad/Keypad.csproj
+++ b/SourceCode/Keypad/Keypad.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 

--- a/SourceCode/ModSim/Source/ModSim.csproj
+++ b/SourceCode/ModSim/Source/ModSim.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <OutputPath>..\..\..\AgOpenGPS\</OutputPath>
     <ApplicationIcon>ModSim_ico.ico</ApplicationIcon>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>


### PR DESCRIPTION
## Summary
- introduce minimal `Visibility` enum and update view model to drop WPF dependency
- retarget AgLibrary and AgOpenGPS.Core to .NET 6 and add a cross-platform console sample
- retarget WinForms projects to .NET 6 for Windows and replace obsolete framework references with NuGet packages

## Testing
- `dotnet --info` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package not found)*
- `dotnet build SourceCode/AgOpenGPS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c47a5450832c9bf62cc81f09b084