### PR TITLE
Add AgOpenGPS.Seeding domain layer (planter rows, metrics, alerts)

### DIFF
--- a/SourceCode/AgOpenGPS.AvaloniaApp/AgOpenGPS.AvaloniaApp.csproj
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/AgOpenGPS.AvaloniaApp.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <RootNamespace>AgOpenGPS.AvaloniaApp</RootNamespace>
+    <AssemblyName>AgOpenGPS.AvaloniaApp</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.2.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.1" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.2.1" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgOpenGPS.Seeding\AgOpenGPS.Seeding.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Config\branding.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/App.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/App.axaml
@@ -1,0 +1,23 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:AgOpenGPS.AvaloniaApp"
+             x:Class="AgOpenGPS.AvaloniaApp.App"
+             RequestedThemeVariant="Dark">
+    <Application.DataTemplates>
+        <local:ViewLocator/>
+    </Application.DataTemplates>
+
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://AgOpenGPS.AvaloniaApp/Themes/Colors.axaml"/>
+                <ResourceInclude Source="avares://AgOpenGPS.AvaloniaApp/Themes/Typography.axaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+
+    <Application.Styles>
+        <FluentTheme/>
+        <StyleInclude Source="avares://AgOpenGPS.AvaloniaApp/Themes/DashboardTheme.axaml"/>
+    </Application.Styles>
+</Application>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/App.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/App.axaml.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+using AgOpenGPS.AvaloniaApp.Services.Branding;
+using AgOpenGPS.AvaloniaApp.Services.Hosting;
+using AgOpenGPS.AvaloniaApp.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AgOpenGPS.AvaloniaApp
+{
+    public partial class App : Application
+    {
+        public static IServiceProvider Services { get; private set; } = null!;
+
+        public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+        public override void OnFrameworkInitializationCompleted()
+        {
+            Services = ServiceRegistration.Build();
+
+            var branding = Services.GetRequiredService<IBrandingService>();
+            ApplyBranding(branding.Current);
+            branding.BrandingChanged += (_, def) =>
+                Dispatcher.UIThread.Post(() => ApplyBranding(def));
+
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                desktop.MainWindow = Services.GetRequiredService<MainWindow>();
+            }
+
+            base.OnFrameworkInitializationCompleted();
+        }
+
+        private void ApplyBranding(BrandingDefinition def)
+        {
+            SetColor("AccentColor", def.AccentColorHex);
+            SetColor("WarningColor", def.WarningColorHex);
+            SetColor("ErrorColor", def.ErrorColorHex);
+            SetColor("BackgroundColor", def.BackgroundColorHex);
+            SetColor("SurfaceColor", def.SurfaceColorHex);
+            SetColor("ForegroundColor", def.ForegroundColorHex);
+        }
+
+        private void SetColor(string key, string hex)
+        {
+            if (TryParseColor(hex, out var color))
+            {
+                Resources[key] = color;
+                Resources[key + "Brush"] = new SolidColorBrush(color);
+            }
+        }
+
+        private static bool TryParseColor(string hex, out Color color)
+        {
+            color = default;
+            if (string.IsNullOrWhiteSpace(hex)) return false;
+            string s = hex.TrimStart('#');
+            if (s.Length == 6) s = "FF" + s;
+            if (s.Length != 8) return false;
+            if (!uint.TryParse(s, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint v)) return false;
+            color = Color.FromArgb((byte)((v >> 24) & 0xFF), (byte)((v >> 16) & 0xFF), (byte)((v >> 8) & 0xFF), (byte)(v & 0xFF));
+            return true;
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Config/branding.json
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Config/branding.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "pilotName": "CentriX",
+  "tagline": "Precision Seeding Co-Pilot",
+  "accentColorHex": "#4CD964",
+  "warningColorHex": "#FF9500",
+  "errorColorHex": "#FF3B30",
+  "backgroundColorHex": "#0E0E0E",
+  "surfaceColorHex": "#1A1A1A",
+  "foregroundColorHex": "#FFFFFF",
+  "fontFamily": "Inter",
+  "showVersionInHeader": true
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Converters/RowStatusToBrushConverter.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Converters/RowStatusToBrushConverter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Globalization;
+using AgOpenGPS.Seeding;
+using Avalonia;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace AgOpenGPS.AvaloniaApp.Converters
+{
+    public sealed class RowStatusToBrushConverter : IValueConverter
+    {
+        public static readonly RowStatusToBrushConverter Instance = new();
+
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is RowAlertSeverity sev)
+            {
+                string key = sev switch
+                {
+                    RowAlertSeverity.Critical => "ErrorColorBrush",
+                    RowAlertSeverity.Warning => "WarningColorBrush",
+                    _ => "AccentColorBrush",
+                };
+                if (Application.Current is { } app && app.Resources.TryGetResource(key, app.ActualThemeVariant, out var res) && res is IBrush brush)
+                    return brush;
+            }
+            return Brushes.Gray;
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => null;
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Program.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Program.cs
@@ -1,0 +1,18 @@
+using System;
+using Avalonia;
+
+namespace AgOpenGPS.AvaloniaApp
+{
+    internal static class Program
+    {
+        [STAThread]
+        public static void Main(string[] args) =>
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+        public static AppBuilder BuildAvaloniaApp() =>
+            AppBuilder.Configure<App>()
+                .UsePlatformDetect()
+                .WithInterFont()
+                .LogToTrace();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Services/Branding/BrandingDefinition.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Services/Branding/BrandingDefinition.cs
@@ -1,0 +1,17 @@
+namespace AgOpenGPS.AvaloniaApp.Services.Branding
+{
+    public sealed class BrandingDefinition
+    {
+        public int SchemaVersion { get; set; } = 1;
+        public string PilotName { get; set; } = "CentriX";
+        public string Tagline { get; set; } = "Precision Seeding Co-Pilot";
+        public string AccentColorHex { get; set; } = "#4CD964";
+        public string WarningColorHex { get; set; } = "#FF9500";
+        public string ErrorColorHex { get; set; } = "#FF3B30";
+        public string BackgroundColorHex { get; set; } = "#0E0E0E";
+        public string SurfaceColorHex { get; set; } = "#1A1A1A";
+        public string ForegroundColorHex { get; set; } = "#FFFFFF";
+        public string FontFamily { get; set; } = "Inter";
+        public bool ShowVersionInHeader { get; set; } = true;
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Services/Branding/BrandingService.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Services/Branding/BrandingService.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace AgOpenGPS.AvaloniaApp.Services.Branding
+{
+    public sealed class BrandingService : IBrandingService, IDisposable
+    {
+        private readonly ILogger<BrandingService>? _logger;
+        private readonly string _packagedPath;
+        private readonly string _userPath;
+        private readonly object _gate = new();
+        private readonly System.Threading.Timer _debounce;
+        private FileSystemWatcher? _packagedWatcher;
+        private FileSystemWatcher? _userWatcher;
+
+        public BrandingService(ILogger<BrandingService>? logger = null)
+        {
+            _logger = logger;
+
+            string baseDir = AppContext.BaseDirectory;
+            _packagedPath = Path.Combine(baseDir, "Config", "branding.json");
+
+            string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            _userPath = Path.Combine(appData, "AgOpenGPS", "branding.json");
+
+            Current = LoadInternal();
+
+            _debounce = new System.Threading.Timer(_ => Reload(), null, System.Threading.Timeout.Infinite, System.Threading.Timeout.Infinite);
+
+            TryWatch(_packagedPath, ref _packagedWatcher);
+            TryWatch(_userPath, ref _userWatcher);
+        }
+
+        public BrandingDefinition Current { get; private set; }
+
+        public event EventHandler<BrandingDefinition>? BrandingChanged;
+
+        public void Reload()
+        {
+            BrandingDefinition next;
+            lock (_gate)
+            {
+                next = LoadInternal();
+                Current = next;
+            }
+            try { BrandingChanged?.Invoke(this, next); }
+            catch (Exception ex) { _logger?.LogError(ex, "BrandingChanged subscriber threw"); }
+        }
+
+        public void Dispose()
+        {
+            _packagedWatcher?.Dispose();
+            _userWatcher?.Dispose();
+            _debounce.Dispose();
+        }
+
+        private BrandingDefinition LoadInternal()
+        {
+            // User override wins over packaged default. Either may be missing — fall back to type defaults.
+            var packaged = TryRead(_packagedPath);
+            var user = TryRead(_userPath);
+            return user ?? packaged ?? new BrandingDefinition();
+        }
+
+        private BrandingDefinition? TryRead(string path)
+        {
+            try
+            {
+                if (!File.Exists(path)) return null;
+                string json = File.ReadAllText(path);
+                if (string.IsNullOrWhiteSpace(json)) return null;
+                var options = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                    ReadCommentHandling = JsonCommentHandling.Skip,
+                    AllowTrailingCommas = true,
+                };
+                return JsonSerializer.Deserialize<BrandingDefinition>(json, options);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to read branding file: {Path}", path);
+                return null;
+            }
+        }
+
+        private void TryWatch(string path, ref FileSystemWatcher? watcher)
+        {
+            try
+            {
+                string? dir = Path.GetDirectoryName(path);
+                if (string.IsNullOrEmpty(dir)) return;
+                if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+                watcher = new FileSystemWatcher(dir, Path.GetFileName(path))
+                {
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName,
+                    EnableRaisingEvents = true,
+                };
+                watcher.Changed += OnChanged;
+                watcher.Created += OnChanged;
+                watcher.Renamed += OnChanged;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Could not watch branding path: {Path}", path);
+            }
+        }
+
+        private void OnChanged(object sender, FileSystemEventArgs e)
+        {
+            // 250ms debounce — editors often write multiple times.
+            _debounce.Change(250, System.Threading.Timeout.Infinite);
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Services/Branding/IBrandingService.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Services/Branding/IBrandingService.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace AgOpenGPS.AvaloniaApp.Services.Branding
+{
+    public interface IBrandingService
+    {
+        BrandingDefinition Current { get; }
+        event EventHandler<BrandingDefinition>? BrandingChanged;
+        void Reload();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Services/Hosting/ServiceRegistration.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Services/Hosting/ServiceRegistration.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using AgOpenGPS.AvaloniaApp.Services.Branding;
+using AgOpenGPS.AvaloniaApp.Services.Seeding;
+using AgOpenGPS.AvaloniaApp.ViewModels;
+using AgOpenGPS.AvaloniaApp.Views;
+using AgOpenGPS.Seeding;
+using AgOpenGPS.Seeding.Sources;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AgOpenGPS.AvaloniaApp.Services.Hosting
+{
+    public static class ServiceRegistration
+    {
+        public static IServiceProvider Build()
+        {
+            var services = new ServiceCollection();
+
+            services.AddLogging(b => b.AddDebug());
+
+            services.AddSingleton<IBrandingService, BrandingService>();
+
+            services.AddSingleton<SeedingTargets>(_ =>
+                new SeedingTargets(targetSeedsPerHectare: 80000, rowSpacingCm: 52.5, boomWidthMeters: 12.6));
+
+            services.AddSingleton<SeedingMonitor>(sp =>
+            {
+                var targets = sp.GetRequiredService<SeedingTargets>();
+                const int rowCount = 24;
+                var rows = new List<PlanterRow>(rowCount);
+                double offset = -((rowCount - 1) * targets.RowSpacingCm / 200.0);
+                for (int i = 0; i < rowCount; i++)
+                {
+                    int sectionIndex = i / (rowCount / 8);
+                    rows.Add(new PlanterRow(i, offset + i * (targets.RowSpacingCm / 100.0), sectionIndex, targets.RowSpacingCm));
+                }
+                return new SeedingMonitor(rows, targets);
+            });
+
+            services.AddSingleton<ISeedingDataSource>(sp =>
+            {
+                var targets = sp.GetRequiredService<SeedingTargets>();
+                return new SimulatedSeedingDataSource(rowCount: 24, targets: targets);
+            });
+
+            services.AddSingleton<SeedingRuntimeHost>();
+            services.AddSingleton<SeedingViewModelAdapter>();
+
+            services.AddSingleton<HeaderBarViewModel>();
+            services.AddSingleton<LeftPorSurcoViewModel>();
+            services.AddSingleton<CenterViewportViewModel>();
+            services.AddSingleton<RightControlViewModel>();
+            services.AddSingleton<BottomAlertsViewModel>();
+            services.AddSingleton<BottomToolbarViewModel>();
+            services.AddSingleton<DashboardViewModel>();
+            services.AddSingleton<MainWindowViewModel>();
+
+            services.AddSingleton<MainWindow>();
+
+            return services.BuildServiceProvider();
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Services/Seeding/SeedingRuntimeHost.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Services/Seeding/SeedingRuntimeHost.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AgOpenGPS.Seeding;
+
+namespace AgOpenGPS.AvaloniaApp.Services.Seeding
+{
+    // Owns the lifecycle of the data source binding to the SeedingMonitor.
+    // Started by MainWindow on Loaded and stopped on Closing.
+    public sealed class SeedingRuntimeHost : IDisposable
+    {
+        private readonly SeedingMonitor _monitor;
+        private readonly ISeedingDataSource _source;
+        private readonly CancellationTokenSource _cts = new();
+        private bool _started;
+
+        public SeedingRuntimeHost(SeedingMonitor monitor, ISeedingDataSource source)
+        {
+            _monitor = monitor;
+            _source = source;
+        }
+
+        public async Task StartAsync()
+        {
+            if (_started) return;
+            _started = true;
+            _monitor.Bind(_source);
+            await _source.StartAsync(_cts.Token).ConfigureAwait(false);
+        }
+
+        public async Task StopAsync()
+        {
+            if (!_started) return;
+            _started = false;
+            try { _cts.Cancel(); } catch { /* ignore */ }
+            try { await _source.StopAsync().ConfigureAwait(false); }
+            catch { /* best effort */ }
+            _monitor.Unbind(_source);
+        }
+
+        public void Dispose()
+        {
+            try { StopAsync().GetAwaiter().GetResult(); }
+            catch { /* best effort */ }
+            _cts.Dispose();
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Services/Seeding/SeedingViewModelAdapter.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Services/Seeding/SeedingViewModelAdapter.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Linq;
+using AgOpenGPS.AvaloniaApp.ViewModels;
+using AgOpenGPS.AvaloniaApp.ViewModels.Items;
+using AgOpenGPS.Seeding;
+using Avalonia.Threading;
+
+namespace AgOpenGPS.AvaloniaApp.Services.Seeding
+{
+    public sealed class SeedingViewModelAdapter : IDisposable
+    {
+        private readonly SeedingMonitor _monitor;
+        private readonly HeaderBarViewModel _header;
+        private readonly LeftPorSurcoViewModel _leftPorSurco;
+        private readonly RightControlViewModel _rightControl;
+        private readonly BottomAlertsViewModel _bottomAlerts;
+        private DateTimeOffset _lastUiUpdate = DateTimeOffset.MinValue;
+
+        public SeedingViewModelAdapter(
+            SeedingMonitor monitor,
+            HeaderBarViewModel header,
+            LeftPorSurcoViewModel leftPorSurco,
+            RightControlViewModel rightControl,
+            BottomAlertsViewModel bottomAlerts)
+        {
+            _monitor = monitor;
+            _header = header;
+            _leftPorSurco = leftPorSurco;
+            _rightControl = rightControl;
+            _bottomAlerts = bottomAlerts;
+
+            // Seed the UI with one row VM per planter row.
+            for (int i = 0; i < monitor.Rows.Count; i++)
+            {
+                _leftPorSurco.Rows.Add(new RowStatusItemViewModel(i + 1));
+            }
+
+            _monitor.SnapshotPublished += OnSnapshot;
+            _monitor.AlertRaised += OnAlert;
+        }
+
+        public void Dispose()
+        {
+            _monitor.SnapshotPublished -= OnSnapshot;
+            _monitor.AlertRaised -= OnAlert;
+        }
+
+        private void OnSnapshot(object? sender, SeedingSnapshot snapshot)
+        {
+            // Throttle to ~10 Hz visually.
+            var now = DateTimeOffset.UtcNow;
+            if ((now - _lastUiUpdate).TotalMilliseconds < 95) return;
+            _lastUiUpdate = now;
+
+            Dispatcher.UIThread.Post(() => Apply(snapshot));
+        }
+
+        private void Apply(SeedingSnapshot snapshot)
+        {
+            _header.SpeedTile.Value = snapshot.SpeedKmh.ToString("F1");
+            _header.RpmTile.Value = ((int)snapshot.MeterShaftRpm).ToString();
+            _header.HectaresTile.Value = snapshot.HectaresWorked.ToString("F1");
+            _header.GpsTile.Value = "RTK";
+            _header.GpsTile.Badge = "FIX";
+
+            _rightControl.TargetSeedsPerMeter = snapshot.TargetSeedsPerMeter;
+            _rightControl.VariationPercent = snapshot.VariationPercent;
+            _rightControl.DoserStatus = "OK";
+
+            for (int i = 0; i < snapshot.Rows.Count && i < _leftPorSurco.Rows.Count; i++)
+            {
+                var metric = snapshot.Rows[i];
+                var vm = _leftPorSurco.Rows[i];
+                vm.SeedsPerMeter = metric.SeedsPerMeter;
+
+                // Severity heuristic from singulation health when no explicit alert is present.
+                if (metric.SkipsPercent > 4) vm.Severity = RowAlertSeverity.Critical;
+                else if (metric.DoublesPercent > 5) vm.Severity = RowAlertSeverity.Warning;
+                else vm.Severity = RowAlertSeverity.Ok;
+            }
+        }
+
+        private void OnAlert(object? sender, RowAlert alert)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                // Cap visible alerts to 4 to match the mockup's bottom bar.
+                while (_bottomAlerts.Alerts.Count >= 4) _bottomAlerts.Alerts.RemoveAt(0);
+                _bottomAlerts.Alerts.Add(new AlertBannerViewModel(
+                    title: $"Surco {alert.RowIndex + 1}",
+                    detail: alert.Message,
+                    severity: alert.Severity));
+
+                if (alert.RowIndex >= 0 && alert.RowIndex < _leftPorSurco.Rows.Count)
+                {
+                    var vm = _leftPorSurco.Rows[alert.RowIndex];
+                    if (alert.Severity > vm.Severity) vm.Severity = alert.Severity;
+                }
+            });
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Themes/Colors.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Themes/Colors.axaml
@@ -1,0 +1,23 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Defaults; BrandingService overrides these at runtime via App.Resources["AccentColor"] = ... -->
+    <Color x:Key="BackgroundColor">#0E0E0E</Color>
+    <Color x:Key="SurfaceColor">#1A1A1A</Color>
+    <Color x:Key="SurfaceElevatedColor">#222222</Color>
+    <Color x:Key="ForegroundColor">#FFFFFF</Color>
+    <Color x:Key="ForegroundMutedColor">#9A9A9A</Color>
+    <Color x:Key="AccentColor">#4CD964</Color>
+    <Color x:Key="WarningColor">#FF9500</Color>
+    <Color x:Key="ErrorColor">#FF3B30</Color>
+    <Color x:Key="DividerColor">#2A2A2A</Color>
+
+    <SolidColorBrush x:Key="BackgroundColorBrush" Color="{DynamicResource BackgroundColor}"/>
+    <SolidColorBrush x:Key="SurfaceColorBrush" Color="{DynamicResource SurfaceColor}"/>
+    <SolidColorBrush x:Key="SurfaceElevatedColorBrush" Color="{DynamicResource SurfaceElevatedColor}"/>
+    <SolidColorBrush x:Key="ForegroundColorBrush" Color="{DynamicResource ForegroundColor}"/>
+    <SolidColorBrush x:Key="ForegroundMutedColorBrush" Color="{DynamicResource ForegroundMutedColor}"/>
+    <SolidColorBrush x:Key="AccentColorBrush" Color="{DynamicResource AccentColor}"/>
+    <SolidColorBrush x:Key="WarningColorBrush" Color="{DynamicResource WarningColor}"/>
+    <SolidColorBrush x:Key="ErrorColorBrush" Color="{DynamicResource ErrorColor}"/>
+    <SolidColorBrush x:Key="DividerColorBrush" Color="{DynamicResource DividerColor}"/>
+</ResourceDictionary>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Themes/DashboardTheme.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Themes/DashboardTheme.axaml
@@ -1,0 +1,102 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style Selector="Window.dashboard">
+        <Setter Property="Background" Value="{DynamicResource BackgroundColorBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource PrimaryFont}"/>
+    </Style>
+
+    <Style Selector="Border.surface">
+        <Setter Property="Background" Value="{DynamicResource SurfaceColorBrush}"/>
+        <Setter Property="CornerRadius" Value="8"/>
+    </Style>
+
+    <Style Selector="Border.kpi">
+        <Setter Property="Background" Value="{DynamicResource SurfaceColorBrush}"/>
+        <Setter Property="CornerRadius" Value="10"/>
+        <Setter Property="Padding" Value="14,8"/>
+        <Setter Property="MinHeight" Value="56"/>
+    </Style>
+
+    <Style Selector="TextBlock.brand">
+        <Setter Property="FontSize" Value="{DynamicResource FontSizeBrand}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundColorBrush}"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+
+    <Style Selector="TextBlock.brandSubtitle">
+        <Setter Property="FontSize" Value="10"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentColorBrush}"/>
+        <Setter Property="LetterSpacing" Value="2"/>
+    </Style>
+
+    <Style Selector="TextBlock.kpiLabel">
+        <Setter Property="FontSize" Value="{DynamicResource FontSizeKpiLabel}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedColorBrush}"/>
+        <Setter Property="LetterSpacing" Value="1"/>
+    </Style>
+
+    <Style Selector="TextBlock.kpiValue">
+        <Setter Property="FontSize" Value="{DynamicResource FontSizeKpi}"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundColorBrush}"/>
+    </Style>
+
+    <Style Selector="TextBlock.kpiUnit">
+        <Setter Property="FontSize" Value="{DynamicResource FontSizeKpiUnit}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedColorBrush}"/>
+        <Setter Property="VerticalAlignment" Value="Bottom"/>
+        <Setter Property="Margin" Value="4,0,0,4"/>
+    </Style>
+
+    <Style Selector="TextBlock.sectionTitle">
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="LetterSpacing" Value="2"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedColorBrush}"/>
+    </Style>
+
+    <Style Selector="Ellipse.statusLed">
+        <Setter Property="Width" Value="10"/>
+        <Setter Property="Height" Value="10"/>
+    </Style>
+
+    <Style Selector="Border.alertCard">
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="Padding" Value="12,6"/>
+        <Setter Property="Background" Value="#1F2A1F"/>
+    </Style>
+
+    <Style Selector="Border.alertCard.warning">
+        <Setter Property="Background" Value="#3A2A0F"/>
+    </Style>
+
+    <Style Selector="Border.alertCard.critical">
+        <Setter Property="Background" Value="#3A1414"/>
+    </Style>
+
+    <Style Selector="Button.toolbar">
+        <Setter Property="Background" Value="{DynamicResource SurfaceColorBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundColorBrush}"/>
+        <Setter Property="CornerRadius" Value="10"/>
+        <Setter Property="Padding" Value="14,8"/>
+        <Setter Property="MinHeight" Value="48"/>
+        <Setter Property="MinWidth" Value="48"/>
+    </Style>
+
+    <Style Selector="Button.toolbar:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource SurfaceElevatedColorBrush}"/>
+    </Style>
+
+    <Style Selector="ToggleButton.toolbar">
+        <Setter Property="Background" Value="{DynamicResource SurfaceColorBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundColorBrush}"/>
+        <Setter Property="CornerRadius" Value="10"/>
+        <Setter Property="Padding" Value="14,8"/>
+        <Setter Property="MinHeight" Value="48"/>
+    </Style>
+
+    <Style Selector="ToggleButton.toolbar:checked /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource AccentColorBrush}"/>
+    </Style>
+</Styles>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Themes/Typography.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Themes/Typography.axaml
@@ -1,0 +1,11 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="using:System">
+    <FontFamily x:Key="PrimaryFont">fonts:Inter#Inter, $Default</FontFamily>
+    <sys:Double x:Key="FontSizeKpi">26</sys:Double>
+    <sys:Double x:Key="FontSizeKpiUnit">12</sys:Double>
+    <sys:Double x:Key="FontSizeKpiLabel">11</sys:Double>
+    <sys:Double x:Key="FontSizeSection">12</sys:Double>
+    <sys:Double x:Key="FontSizeBody">13</sys:Double>
+    <sys:Double x:Key="FontSizeBrand">22</sys:Double>
+</ResourceDictionary>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewLocator.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewLocator.cs
@@ -1,0 +1,22 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using AgOpenGPS.AvaloniaApp.ViewModels;
+
+namespace AgOpenGPS.AvaloniaApp
+{
+    public sealed class ViewLocator : IDataTemplate
+    {
+        public Control Build(object? data)
+        {
+            if (data is null) return new TextBlock { Text = "(null view-model)" };
+            string fullName = data.GetType().FullName ?? "";
+            string viewName = fullName.Replace(".ViewModels.", ".Views.").Replace("ViewModel", "View");
+            var type = Type.GetType(viewName);
+            if (type is null) return new TextBlock { Text = "View not found: " + viewName };
+            return (Control)Activator.CreateInstance(type)!;
+        }
+
+        public bool Match(object? data) => data is ViewModelBase;
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/BottomAlertsViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/BottomAlertsViewModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.ObjectModel;
+using AgOpenGPS.AvaloniaApp.ViewModels.Items;
+
+namespace AgOpenGPS.AvaloniaApp.ViewModels
+{
+    public partial class BottomAlertsViewModel : ViewModelBase
+    {
+        public ObservableCollection<AlertBannerViewModel> Alerts { get; } = new();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/BottomToolbarViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/BottomToolbarViewModel.cs
@@ -1,0 +1,32 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AgOpenGPS.AvaloniaApp.ViewModels
+{
+    public partial class BottomToolbarViewModel : ViewModelBase
+    {
+        [ObservableProperty]
+        private bool _isAutoSteerOn;
+
+        [ObservableProperty]
+        private bool _isSectionMasterAuto = true;
+
+        [ObservableProperty]
+        private bool _isPlaying;
+
+        [RelayCommand]
+        private void ToggleAutoSteer() => IsAutoSteerOn = !IsAutoSteerOn;
+
+        [RelayCommand]
+        private void ToggleMasterAuto() => IsSectionMasterAuto = !IsSectionMasterAuto;
+
+        [RelayCommand]
+        private void TogglePlay() => IsPlaying = !IsPlaying;
+
+        [RelayCommand]
+        private void NextLine() { }
+
+        [RelayCommand]
+        private void PreviousLine() { }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/CenterViewportViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/CenterViewportViewModel.cs
@@ -1,0 +1,10 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AgOpenGPS.AvaloniaApp.ViewModels
+{
+    public partial class CenterViewportViewModel : ViewModelBase
+    {
+        [ObservableProperty]
+        private string _placeholder = "Vista 3D del campo (placeholder — viewport OpenGL en Fase 5)";
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/DashboardViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/DashboardViewModel.cs
@@ -1,0 +1,28 @@
+namespace AgOpenGPS.AvaloniaApp.ViewModels
+{
+    public sealed class DashboardViewModel : ViewModelBase
+    {
+        public HeaderBarViewModel Header { get; }
+        public LeftPorSurcoViewModel LeftPorSurco { get; }
+        public CenterViewportViewModel CenterViewport { get; }
+        public RightControlViewModel RightControl { get; }
+        public BottomAlertsViewModel BottomAlerts { get; }
+        public BottomToolbarViewModel BottomToolbar { get; }
+
+        public DashboardViewModel(
+            HeaderBarViewModel header,
+            LeftPorSurcoViewModel leftPorSurco,
+            CenterViewportViewModel centerViewport,
+            RightControlViewModel rightControl,
+            BottomAlertsViewModel bottomAlerts,
+            BottomToolbarViewModel bottomToolbar)
+        {
+            Header = header;
+            LeftPorSurco = leftPorSurco;
+            CenterViewport = centerViewport;
+            RightControl = rightControl;
+            BottomAlerts = bottomAlerts;
+            BottomToolbar = bottomToolbar;
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/HeaderBarViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/HeaderBarViewModel.cs
@@ -1,0 +1,44 @@
+using System;
+using AgOpenGPS.AvaloniaApp.Services.Branding;
+using AgOpenGPS.AvaloniaApp.ViewModels.Items;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AgOpenGPS.AvaloniaApp.ViewModels
+{
+    public partial class HeaderBarViewModel : ViewModelBase
+    {
+        private readonly IBrandingService _branding;
+
+        [ObservableProperty]
+        private string _pilotName = "CentriX";
+
+        [ObservableProperty]
+        private string _tagline = string.Empty;
+
+        public KpiTileViewModel SpeedTile { get; } = new("VELOCIDAD", "km/h");
+        public KpiTileViewModel RpmTile { get; } = new("RPM", "rpm");
+        public KpiTileViewModel GpsTile { get; } = new("GPS", "");
+        public KpiTileViewModel HectaresTile { get; } = new("HECTAREAS", "ha");
+
+        public HeaderBarViewModel(IBrandingService branding)
+        {
+            _branding = branding;
+            ApplyBranding(branding.Current);
+            branding.BrandingChanged += OnBrandingChanged;
+
+            GpsTile.Value = "—";
+            GpsTile.Badge = "NO FIX";
+            SpeedTile.Value = "0.0";
+            RpmTile.Value = "0";
+            HectaresTile.Value = "0.0";
+        }
+
+        private void OnBrandingChanged(object? sender, BrandingDefinition def) => ApplyBranding(def);
+
+        private void ApplyBranding(BrandingDefinition def)
+        {
+            PilotName = def.PilotName;
+            Tagline = def.Tagline;
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/Items/AlertBannerViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/Items/AlertBannerViewModel.cs
@@ -1,0 +1,26 @@
+using AgOpenGPS.Seeding;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AgOpenGPS.AvaloniaApp.ViewModels.Items
+{
+    public partial class AlertBannerViewModel : ViewModelBase
+    {
+        [ObservableProperty]
+        private string _title = string.Empty;
+
+        [ObservableProperty]
+        private string _detail = string.Empty;
+
+        [ObservableProperty]
+        private RowAlertSeverity _severity;
+
+        public AlertBannerViewModel() { }
+
+        public AlertBannerViewModel(string title, string detail, RowAlertSeverity severity)
+        {
+            _title = title;
+            _detail = detail;
+            _severity = severity;
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/Items/KpiTileViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/Items/KpiTileViewModel.cs
@@ -1,0 +1,27 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AgOpenGPS.AvaloniaApp.ViewModels.Items
+{
+    public partial class KpiTileViewModel : ViewModelBase
+    {
+        [ObservableProperty]
+        private string _label = string.Empty;
+
+        [ObservableProperty]
+        private string _value = string.Empty;
+
+        [ObservableProperty]
+        private string _unit = string.Empty;
+
+        [ObservableProperty]
+        private string _badge = string.Empty;
+
+        public KpiTileViewModel() { }
+
+        public KpiTileViewModel(string label, string unit)
+        {
+            _label = label;
+            _unit = unit;
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/Items/RowStatusItemViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/Items/RowStatusItemViewModel.cs
@@ -1,0 +1,25 @@
+using AgOpenGPS.Seeding;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AgOpenGPS.AvaloniaApp.ViewModels.Items
+{
+    public partial class RowStatusItemViewModel : ViewModelBase
+    {
+        [ObservableProperty]
+        private int _rowNumber;
+
+        [ObservableProperty]
+        private double _seedsPerMeter;
+
+        [ObservableProperty]
+        private RowAlertSeverity _severity;
+
+        public RowStatusItemViewModel() { }
+
+        public RowStatusItemViewModel(int rowNumber)
+        {
+            _rowNumber = rowNumber;
+            _severity = RowAlertSeverity.Ok;
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/LeftPorSurcoViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/LeftPorSurcoViewModel.cs
@@ -1,0 +1,16 @@
+using System.Collections.ObjectModel;
+using AgOpenGPS.AvaloniaApp.ViewModels.Items;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AgOpenGPS.AvaloniaApp.ViewModels
+{
+    public partial class LeftPorSurcoViewModel : ViewModelBase
+    {
+        [ObservableProperty]
+        private string _title = "POR SURCO";
+
+        public ObservableCollection<RowStatusItemViewModel> Rows { get; } = new();
+
+        public LeftPorSurcoViewModel() { }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/MainWindowViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,12 @@
+namespace AgOpenGPS.AvaloniaApp.ViewModels
+{
+    public sealed class MainWindowViewModel : ViewModelBase
+    {
+        public DashboardViewModel Dashboard { get; }
+
+        public MainWindowViewModel(DashboardViewModel dashboard)
+        {
+            Dashboard = dashboard;
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/RightControlViewModel.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/RightControlViewModel.cs
@@ -1,0 +1,25 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AgOpenGPS.AvaloniaApp.ViewModels
+{
+    public partial class RightControlViewModel : ViewModelBase
+    {
+        [ObservableProperty]
+        private string _title = "CONTROL";
+
+        [ObservableProperty]
+        private double _targetSeedsPerMeter = 5.2;
+
+        [ObservableProperty]
+        private double _variationPercent;
+
+        [ObservableProperty]
+        private string _doserStatus = "OK";
+
+        [ObservableProperty]
+        private string _currentLine = "1 L";
+
+        [ObservableProperty]
+        private double _overlapCm = 2.3;
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/ViewModelBase.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/ViewModels/ViewModelBase.cs
@@ -1,0 +1,8 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AgOpenGPS.AvaloniaApp.ViewModels
+{
+    public abstract class ViewModelBase : ObservableObject
+    {
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/BottomAlertsView.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/BottomAlertsView.axaml
@@ -1,0 +1,18 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels"
+             x:Class="AgOpenGPS.AvaloniaApp.Views.BottomAlertsView"
+             x:DataType="vm:BottomAlertsViewModel">
+    <Border Classes="surface" Padding="12,8">
+        <DockPanel>
+            <TextBlock DockPanel.Dock="Left" Classes="sectionTitle" Text="ALERTAS" VerticalAlignment="Center" Margin="0,0,18,0"/>
+            <ItemsControl ItemsSource="{Binding Alerts}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="10"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+            </ItemsControl>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/BottomAlertsView.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/BottomAlertsView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace AgOpenGPS.AvaloniaApp.Views
+{
+    public partial class BottomAlertsView : UserControl
+    {
+        public BottomAlertsView() => InitializeComponent();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/BottomToolbarView.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/BottomToolbarView.axaml
@@ -1,0 +1,15 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels"
+             x:Class="AgOpenGPS.AvaloniaApp.Views.BottomToolbarView"
+             x:DataType="vm:BottomToolbarViewModel">
+    <Border Classes="surface" Padding="12,8">
+        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+            <ToggleButton Classes="toolbar" Content="SECCIONES AUTO" IsChecked="{Binding IsSectionMasterAuto}" Command="{Binding ToggleMasterAutoCommand}"/>
+            <Button Classes="toolbar" Content="| AB |" Command="{Binding PreviousLineCommand}"/>
+            <ToggleButton Classes="toolbar" Content="▶ PLAY" IsChecked="{Binding IsPlaying}" Command="{Binding TogglePlayCommand}"/>
+            <Button Classes="toolbar" Content="| AB ▶" Command="{Binding NextLineCommand}"/>
+            <ToggleButton Classes="toolbar" Content="AUTOSTEER" IsChecked="{Binding IsAutoSteerOn}" Command="{Binding ToggleAutoSteerCommand}"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/BottomToolbarView.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/BottomToolbarView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace AgOpenGPS.AvaloniaApp.Views
+{
+    public partial class BottomToolbarView : UserControl
+    {
+        public BottomToolbarView() => InitializeComponent();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/CenterViewportView.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/CenterViewportView.axaml
@@ -1,0 +1,14 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels"
+             x:Class="AgOpenGPS.AvaloniaApp.Views.CenterViewportView"
+             x:DataType="vm:CenterViewportViewModel">
+    <Border Classes="surface" Background="#08120A">
+        <Grid>
+            <TextBlock Text="{Binding Placeholder}"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       Foreground="{DynamicResource ForegroundMutedColorBrush}"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/CenterViewportView.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/CenterViewportView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace AgOpenGPS.AvaloniaApp.Views
+{
+    public partial class CenterViewportView : UserControl
+    {
+        public CenterViewportView() => InitializeComponent();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/DashboardView.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/DashboardView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels"
+             x:Class="AgOpenGPS.AvaloniaApp.Views.DashboardView"
+             x:DataType="vm:DashboardViewModel">
+    <Grid RowDefinitions="80,*,52,80" ColumnDefinitions="240,*,320" Margin="12">
+        <ContentControl Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Content="{Binding Header}"/>
+
+        <ContentControl Grid.Row="1" Grid.Column="0" Margin="0,12,12,0" Content="{Binding LeftPorSurco}"/>
+        <ContentControl Grid.Row="1" Grid.Column="1" Margin="0,12,0,0" Content="{Binding CenterViewport}"/>
+        <ContentControl Grid.Row="1" Grid.Column="2" Margin="12,12,0,0" Content="{Binding RightControl}"/>
+
+        <ContentControl Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,12,0,0" Content="{Binding BottomAlerts}"/>
+        <ContentControl Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,12,0,0" Content="{Binding BottomToolbar}"/>
+    </Grid>
+</UserControl>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/DashboardView.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/DashboardView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace AgOpenGPS.AvaloniaApp.Views
+{
+    public partial class DashboardView : UserControl
+    {
+        public DashboardView() => InitializeComponent();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/HeaderBarView.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/HeaderBarView.axaml
@@ -1,0 +1,25 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels"
+             x:Class="AgOpenGPS.AvaloniaApp.Views.HeaderBarView"
+             x:DataType="vm:HeaderBarViewModel">
+    <Border Classes="surface" Padding="16,10">
+        <Grid ColumnDefinitions="Auto,*,Auto">
+            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Classes="brand" Text="{Binding PilotName}"/>
+                <TextBlock Classes="brandSubtitle" Text="{Binding Tagline}"/>
+            </StackPanel>
+
+            <StackPanel Grid.Column="1"
+                        Orientation="Horizontal"
+                        Spacing="14"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                <ContentControl Content="{Binding SpeedTile}" MinWidth="160"/>
+                <ContentControl Content="{Binding RpmTile}" MinWidth="160"/>
+                <ContentControl Content="{Binding GpsTile}" MinWidth="160"/>
+                <ContentControl Content="{Binding HectaresTile}" MinWidth="160"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/HeaderBarView.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/HeaderBarView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace AgOpenGPS.AvaloniaApp.Views
+{
+    public partial class HeaderBarView : UserControl
+    {
+        public HeaderBarView() => InitializeComponent();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/AlertBannerView.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/AlertBannerView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels.Items"
+             x:Class="AgOpenGPS.AvaloniaApp.Views.Items.AlertBannerView"
+             x:DataType="vm:AlertBannerViewModel">
+    <Border Name="Root" Classes="alertCard">
+        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+            <TextBlock Text="{Binding Title}" FontWeight="Bold" Foreground="{DynamicResource ForegroundColorBrush}"/>
+            <TextBlock Text="{Binding Detail}" Foreground="{DynamicResource ForegroundMutedColorBrush}"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/AlertBannerView.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/AlertBannerView.axaml.cs
@@ -1,0 +1,39 @@
+using System;
+using AgOpenGPS.AvaloniaApp.ViewModels.Items;
+using AgOpenGPS.Seeding;
+using Avalonia.Controls;
+
+namespace AgOpenGPS.AvaloniaApp.Views.Items
+{
+    public partial class AlertBannerView : UserControl
+    {
+        public AlertBannerView()
+        {
+            InitializeComponent();
+            DataContextChanged += OnDataContextChanged;
+        }
+
+        private void OnDataContextChanged(object? sender, EventArgs e)
+        {
+            if (DataContext is AlertBannerViewModel vm)
+            {
+                ApplySeverity(vm.Severity);
+                vm.PropertyChanged += (_, args) =>
+                {
+                    if (args.PropertyName == nameof(AlertBannerViewModel.Severity))
+                        ApplySeverity(vm.Severity);
+                };
+            }
+        }
+
+        private void ApplySeverity(RowAlertSeverity severity)
+        {
+            var border = this.FindControl<Border>("Root");
+            if (border is null) return;
+            border.Classes.Remove("warning");
+            border.Classes.Remove("critical");
+            if (severity == RowAlertSeverity.Warning) border.Classes.Add("warning");
+            else if (severity == RowAlertSeverity.Critical) border.Classes.Add("critical");
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/KpiTileView.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/KpiTileView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels.Items"
+             x:Class="AgOpenGPS.AvaloniaApp.Views.Items.KpiTileView"
+             x:DataType="vm:KpiTileViewModel">
+    <Border Classes="kpi">
+        <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,Auto">
+            <TextBlock Grid.Row="0" Grid.Column="0" Classes="kpiLabel" Text="{Binding Label}"/>
+            <TextBlock Grid.Row="0" Grid.Column="1" Classes="kpiLabel" Text="{Binding Badge}" Foreground="{DynamicResource AccentColorBrush}"/>
+            <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="0">
+                <TextBlock Classes="kpiValue" Text="{Binding Value}"/>
+                <TextBlock Classes="kpiUnit" Text="{Binding Unit}"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/KpiTileView.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/KpiTileView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace AgOpenGPS.AvaloniaApp.Views.Items
+{
+    public partial class KpiTileView : UserControl
+    {
+        public KpiTileView() => InitializeComponent();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/RowStatusItemView.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/RowStatusItemView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels.Items"
+             xmlns:cv="clr-namespace:AgOpenGPS.AvaloniaApp.Converters"
+             x:Class="AgOpenGPS.AvaloniaApp.Views.Items.RowStatusItemView"
+             x:DataType="vm:RowStatusItemViewModel">
+    <Grid ColumnDefinitions="*,*,*" Height="22">
+        <TextBlock Grid.Column="0" Text="{Binding RowNumber}" VerticalAlignment="Center" Foreground="{DynamicResource ForegroundColorBrush}"/>
+        <TextBlock Grid.Column="1" Text="{Binding SeedsPerMeter, StringFormat={}{0:F1}}" VerticalAlignment="Center" Foreground="{DynamicResource ForegroundColorBrush}"/>
+        <Ellipse Grid.Column="2"
+                 Classes="statusLed"
+                 HorizontalAlignment="Right"
+                 VerticalAlignment="Center"
+                 Fill="{Binding Severity, Converter={x:Static cv:RowStatusToBrushConverter.Instance}}"/>
+    </Grid>
+</UserControl>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/RowStatusItemView.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/Items/RowStatusItemView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace AgOpenGPS.AvaloniaApp.Views.Items
+{
+    public partial class RowStatusItemView : UserControl
+    {
+        public RowStatusItemView() => InitializeComponent();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/LeftPorSurcoView.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/LeftPorSurcoView.axaml
@@ -1,0 +1,25 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels"
+             x:Class="AgOpenGPS.AvaloniaApp.Views.LeftPorSurcoView"
+             x:DataType="vm:LeftPorSurcoViewModel">
+    <Border Classes="surface" Padding="14,12">
+        <DockPanel>
+            <TextBlock DockPanel.Dock="Top" Classes="sectionTitle" Text="{Binding Title}" Margin="0,0,0,10"/>
+            <Grid DockPanel.Dock="Top" ColumnDefinitions="*,*,*" Margin="0,0,0,6">
+                <TextBlock Grid.Column="0" Classes="kpiLabel" Text="SURCO"/>
+                <TextBlock Grid.Column="1" Classes="kpiLabel" Text="SEM/M"/>
+                <TextBlock Grid.Column="2" Classes="kpiLabel" Text="ESTADO" HorizontalAlignment="Right"/>
+            </Grid>
+            <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+                <ItemsControl ItemsSource="{Binding Rows}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Spacing="2"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/LeftPorSurcoView.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/LeftPorSurcoView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace AgOpenGPS.AvaloniaApp.Views
+{
+    public partial class LeftPorSurcoView : UserControl
+    {
+        public LeftPorSurcoView() => InitializeComponent();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/MainWindow.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/MainWindow.axaml
@@ -1,0 +1,15 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels"
+        xmlns:v="clr-namespace:AgOpenGPS.AvaloniaApp.Views"
+        x:Class="AgOpenGPS.AvaloniaApp.Views.MainWindow"
+        x:DataType="vm:MainWindowViewModel"
+        Title="AgOpenGPS"
+        Width="1672"
+        Height="940"
+        MinWidth="1280"
+        MinHeight="780"
+        Classes="dashboard"
+        Background="{DynamicResource BackgroundColorBrush}">
+    <ContentControl Content="{Binding Dashboard}"/>
+</Window>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/MainWindow.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/MainWindow.axaml.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using AgOpenGPS.AvaloniaApp.Services.Seeding;
+using AgOpenGPS.AvaloniaApp.ViewModels;
+using Avalonia.Controls;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AgOpenGPS.AvaloniaApp.Views
+{
+    public partial class MainWindow : Window
+    {
+        private SeedingRuntimeHost? _runtime;
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            DataContext = App.Services.GetRequiredService<MainWindowViewModel>();
+            // Touch the adapter so it subscribes to the monitor before snapshots fire.
+            _ = App.Services.GetRequiredService<SeedingViewModelAdapter>();
+            _runtime = App.Services.GetRequiredService<SeedingRuntimeHost>();
+
+            Opened += OnOpened;
+            Closing += OnClosing;
+        }
+
+        private async void OnOpened(object? sender, EventArgs e)
+        {
+            try
+            {
+                if (_runtime is not null) await _runtime.StartAsync();
+            }
+            catch
+            {
+                // Surface in logging in a future iteration; non-fatal for UI startup.
+            }
+        }
+
+        private async void OnClosing(object? sender, WindowClosingEventArgs e)
+        {
+            if (_runtime is null) return;
+            var local = _runtime;
+            _runtime = null;
+            try { await local.StopAsync(); } catch { }
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/RightControlView.axaml
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/RightControlView.axaml
@@ -1,0 +1,48 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:AgOpenGPS.AvaloniaApp.ViewModels"
+             x:Class="AgOpenGPS.AvaloniaApp.Views.RightControlView"
+             x:DataType="vm:RightControlViewModel">
+    <Border Classes="surface" Padding="16,14">
+        <StackPanel Spacing="14">
+            <TextBlock Classes="sectionTitle" Text="{Binding Title}"/>
+
+            <StackPanel Spacing="2">
+                <TextBlock Classes="kpiLabel" Text="DENSIDAD OBJETIVO"/>
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <TextBlock Classes="kpiValue" Text="{Binding TargetSeedsPerMeter, StringFormat={}{0:F1}}"/>
+                    <TextBlock Classes="kpiUnit" Text="sem/m"/>
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel Spacing="2">
+                <TextBlock Classes="kpiLabel" Text="VARIACION"/>
+                <TextBlock FontSize="20"
+                           FontWeight="SemiBold"
+                           Foreground="{DynamicResource AccentColorBrush}"
+                           Text="{Binding VariationPercent, StringFormat={}{0:+0.0;-0.0;0.0} %}"/>
+            </StackPanel>
+
+            <StackPanel Spacing="2">
+                <TextBlock Classes="kpiLabel" Text="ESTADO DOSIFICADOR"/>
+                <TextBlock FontSize="16"
+                           FontWeight="SemiBold"
+                           Foreground="{DynamicResource AccentColorBrush}"
+                           Text="{Binding DoserStatus}"/>
+            </StackPanel>
+
+            <StackPanel Spacing="2">
+                <TextBlock Classes="kpiLabel" Text="LINEA ACTUAL"/>
+                <TextBlock FontSize="16" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundColorBrush}" Text="{Binding CurrentLine}"/>
+            </StackPanel>
+
+            <StackPanel Spacing="2">
+                <TextBlock Classes="kpiLabel" Text="SUPERPOSICION"/>
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <TextBlock Classes="kpiValue" Text="{Binding OverlapCm, StringFormat={}{0:F1}}"/>
+                    <TextBlock Classes="kpiUnit" Text="cm"/>
+                </StackPanel>
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/SourceCode/AgOpenGPS.AvaloniaApp/Views/RightControlView.axaml.cs
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/Views/RightControlView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace AgOpenGPS.AvaloniaApp.Views
+{
+    public partial class RightControlView : UserControl
+    {
+        public RightControlView() => InitializeComponent();
+    }
+}

--- a/SourceCode/AgOpenGPS.AvaloniaApp/app.manifest
+++ b/SourceCode/AgOpenGPS.AvaloniaApp/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="AgOpenGPS.AvaloniaApp" />
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/SourceCode/AgOpenGPS.Seeding.Tests/AgOpenGPS.Seeding.Tests.csproj
+++ b/SourceCode/AgOpenGPS.Seeding.Tests/AgOpenGPS.Seeding.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgOpenGPS.Seeding\AgOpenGPS.Seeding.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SourceCode/AgOpenGPS.Seeding.Tests/SeedingMonitorTests.cs
+++ b/SourceCode/AgOpenGPS.Seeding.Tests/SeedingMonitorTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AgOpenGPS.Seeding.Sources;
+using NUnit.Framework;
+
+namespace AgOpenGPS.Seeding.Tests
+{
+    public class SeedingMonitorTests
+    {
+        private static SeedingMonitor BuildMonitor(int rowCount = 6)
+        {
+            var targets = new SeedingTargets(targetSeedsPerHectare: 80000, rowSpacingCm: 52.5, boomWidthMeters: rowCount * 0.525);
+            var rows = new List<PlanterRow>();
+            for (int i = 0; i < rowCount; i++)
+                rows.Add(new PlanterRow(i, i * 0.525, i / 2, targets.RowSpacingCm));
+            return new SeedingMonitor(rows, targets);
+        }
+
+        [Test]
+        public async Task Bind_ForwardsSnapshotsAndCachesLast()
+        {
+            var monitor = BuildMonitor();
+            using var src = new SimulatedSeedingDataSource(rowCount: 6, sampleHz: 100, randomSeed: 1);
+
+            int seen = 0;
+            monitor.SnapshotPublished += (_, _) => seen++;
+            monitor.Bind(src);
+
+            await src.StartAsync(CancellationToken.None);
+            await Task.Delay(120);
+            await src.StopAsync();
+
+            Assert.That(seen, Is.GreaterThan(0));
+            Assert.That(monitor.LastSnapshot, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task Unbind_StopsForwarding()
+        {
+            var monitor = BuildMonitor();
+            using var src = new SimulatedSeedingDataSource(rowCount: 6, sampleHz: 100, randomSeed: 2);
+            monitor.Bind(src);
+
+            int beforeUnbind = 0;
+            monitor.SnapshotPublished += (_, _) => beforeUnbind++;
+
+            await src.StartAsync(CancellationToken.None);
+            await Task.Delay(80);
+            monitor.Unbind(src);
+            int snapshotCountAtUnbind = beforeUnbind;
+            await Task.Delay(80);
+            await src.StopAsync();
+
+            Assert.That(beforeUnbind, Is.EqualTo(snapshotCountAtUnbind),
+                "no further snapshots should be forwarded after Unbind");
+        }
+
+        [Test]
+        public void Constructor_NullRows_Throws()
+        {
+            var targets = new SeedingTargets(80000, 52.5, 12.6);
+            Assert.Throws<ArgumentNullException>(() => new SeedingMonitor(null!, targets));
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding.Tests/SeedingTargetsTests.cs
+++ b/SourceCode/AgOpenGPS.Seeding.Tests/SeedingTargetsTests.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+
+namespace AgOpenGPS.Seeding.Tests
+{
+    public class SeedingTargetsTests
+    {
+        [Test]
+        public void TargetSeedsPerMeterPerRow_With52_5cmRows_And80kPopulation_IsAround4_2()
+        {
+            var targets = new SeedingTargets(targetSeedsPerHectare: 80000, rowSpacingCm: 52.5, boomWidthMeters: 12.6);
+
+            // 80000 seeds/ha * 0.525 m / 10000 m^2/ha = 4.2 seeds/m per row.
+            Assert.That(targets.TargetSeedsPerMeterPerRow, Is.EqualTo(4.2).Within(0.001));
+        }
+
+        [Test]
+        public void TargetSeedsPerMeterPerRow_WithZeroRowSpacing_ReturnsZero()
+        {
+            var targets = new SeedingTargets(targetSeedsPerHectare: 80000, rowSpacingCm: 0, boomWidthMeters: 12.6);
+
+            Assert.That(targets.TargetSeedsPerMeterPerRow, Is.EqualTo(0));
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding.Tests/SimulatedSeedingDataSourceTests.cs
+++ b/SourceCode/AgOpenGPS.Seeding.Tests/SimulatedSeedingDataSourceTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AgOpenGPS.Seeding.Sources;
+using NUnit.Framework;
+
+namespace AgOpenGPS.Seeding.Tests
+{
+    public class SimulatedSeedingDataSourceTests
+    {
+        [Test]
+        public async Task Start_EmitsSnapshotsWithExpectedRowCount()
+        {
+            using var src = new SimulatedSeedingDataSource(rowCount: 24, sampleHz: 100, randomSeed: 42);
+            var snapshots = new List<SeedingSnapshot>();
+            src.SnapshotReceived += (_, s) => snapshots.Add(s);
+
+            await src.StartAsync(CancellationToken.None);
+            await Task.Delay(150);
+            await src.StopAsync();
+
+            Assert.That(snapshots, Is.Not.Empty, "expected at least one snapshot");
+            Assert.That(snapshots[0].Rows.Count, Is.EqualTo(24));
+        }
+
+        [Test]
+        public async Task Start_PopulatesPerRowMetricsWithinSaneRange()
+        {
+            using var src = new SimulatedSeedingDataSource(rowCount: 12, sampleHz: 100, randomSeed: 7);
+            SeedingSnapshot? captured = null;
+            src.SnapshotReceived += (_, s) => captured ??= s;
+
+            await src.StartAsync(CancellationToken.None);
+            await Task.Delay(80);
+            await src.StopAsync();
+
+            Assert.That(captured, Is.Not.Null);
+            Assert.That(captured!.SpeedKmh, Is.GreaterThan(0));
+            Assert.That(captured.MeterShaftRpm, Is.GreaterThan(0));
+            foreach (var row in captured.Rows)
+            {
+                Assert.That(row.SeedsPerMeter, Is.GreaterThanOrEqualTo(0));
+                Assert.That(row.SingulationPercent, Is.InRange(0, 100));
+            }
+        }
+
+        [Test]
+        public async Task StopAsync_CompletesEvenWithoutStart()
+        {
+            using var src = new SimulatedSeedingDataSource(rowCount: 4, sampleHz: 50);
+            await src.StopAsync();
+            Assert.That(src.IsRunning, Is.False);
+        }
+
+        [Test]
+        public async Task ExternalCancellation_StopsLoop()
+        {
+            using var src = new SimulatedSeedingDataSource(rowCount: 8, sampleHz: 50);
+            using var cts = new CancellationTokenSource();
+
+            await src.StartAsync(cts.Token);
+            cts.Cancel();
+            await Task.Delay(100);
+            await src.StopAsync();
+
+            Assert.That(src.IsRunning, Is.False);
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding/AgOpenGPS.Seeding.csproj
+++ b/SourceCode/AgOpenGPS.Seeding/AgOpenGPS.Seeding.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <RootNamespace>AgOpenGPS.Seeding</RootNamespace>
+    <AssemblyName>AgOpenGPS.Seeding</AssemblyName>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+</Project>

--- a/SourceCode/AgOpenGPS.Seeding/ISeedingDataSource.cs
+++ b/SourceCode/AgOpenGPS.Seeding/ISeedingDataSource.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AgOpenGPS.Seeding
+{
+    public interface ISeedingDataSource
+    {
+        event EventHandler<SeedingSnapshot>? SnapshotReceived;
+        event EventHandler<RowAlert>? AlertReceived;
+
+        int RowCount { get; }
+        bool IsRunning { get; }
+
+        Task StartAsync(CancellationToken cancellationToken);
+        Task StopAsync();
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding/PlanterRow.cs
+++ b/SourceCode/AgOpenGPS.Seeding/PlanterRow.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace AgOpenGPS.Seeding
+{
+    public sealed class PlanterRow
+    {
+        public PlanterRow(int index, double offsetMeters, int associatedSectionIndex, double nominalSeedSpacingCm)
+        {
+            if (index < 0) throw new ArgumentOutOfRangeException(nameof(index));
+            Index = index;
+            OffsetMeters = offsetMeters;
+            AssociatedSectionIndex = associatedSectionIndex;
+            NominalSeedSpacingCm = nominalSeedSpacingCm;
+            IsEnabled = true;
+        }
+
+        public int Index { get; }
+
+        public double OffsetMeters { get; }
+
+        public int AssociatedSectionIndex { get; }
+
+        public double NominalSeedSpacingCm { get; }
+
+        public bool IsEnabled { get; set; }
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding/RowAlert.cs
+++ b/SourceCode/AgOpenGPS.Seeding/RowAlert.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace AgOpenGPS.Seeding
+{
+    public enum RowAlertSeverity
+    {
+        Ok = 0,
+        Warning = 1,
+        Critical = 2,
+    }
+
+    public enum RowAlertCode
+    {
+        None = 0,
+        NoFlow,
+        PartialFlow,
+        DoubleSeed,
+        Skip,
+        LowDensity,
+        OutOfRangeSpeed,
+        SensorFault,
+    }
+
+    public sealed class RowAlert
+    {
+        public RowAlert(int rowIndex, RowAlertSeverity severity, RowAlertCode code, string? message, DateTimeOffset raisedAt)
+        {
+            RowIndex = rowIndex;
+            Severity = severity;
+            Code = code;
+            Message = message ?? string.Empty;
+            RaisedAt = raisedAt;
+        }
+
+        public int RowIndex { get; }
+        public RowAlertSeverity Severity { get; }
+        public RowAlertCode Code { get; }
+        public string Message { get; }
+        public DateTimeOffset RaisedAt { get; }
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding/RowMetric.cs
+++ b/SourceCode/AgOpenGPS.Seeding/RowMetric.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace AgOpenGPS.Seeding
+{
+    public readonly struct RowMetric : IEquatable<RowMetric>
+    {
+        public RowMetric(
+            int rowIndex,
+            double seedsPerSecond,
+            double seedsPerMeter,
+            double singulationPercent,
+            double doublesPercent,
+            double skipsPercent,
+            double meterRpm,
+            DateTimeOffset timestamp)
+        {
+            RowIndex = rowIndex;
+            SeedsPerSecond = seedsPerSecond;
+            SeedsPerMeter = seedsPerMeter;
+            SingulationPercent = singulationPercent;
+            DoublesPercent = doublesPercent;
+            SkipsPercent = skipsPercent;
+            MeterRpm = meterRpm;
+            Timestamp = timestamp;
+        }
+
+        public int RowIndex { get; }
+        public double SeedsPerSecond { get; }
+        public double SeedsPerMeter { get; }
+        public double SingulationPercent { get; }
+        public double DoublesPercent { get; }
+        public double SkipsPercent { get; }
+        public double MeterRpm { get; }
+        public DateTimeOffset Timestamp { get; }
+
+        public bool Equals(RowMetric other) =>
+            RowIndex == other.RowIndex &&
+            SeedsPerSecond.Equals(other.SeedsPerSecond) &&
+            SeedsPerMeter.Equals(other.SeedsPerMeter) &&
+            SingulationPercent.Equals(other.SingulationPercent) &&
+            DoublesPercent.Equals(other.DoublesPercent) &&
+            SkipsPercent.Equals(other.SkipsPercent) &&
+            MeterRpm.Equals(other.MeterRpm) &&
+            Timestamp.Equals(other.Timestamp);
+
+        public override bool Equals(object? obj) => obj is RowMetric other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 31 + RowIndex.GetHashCode();
+                hash = hash * 31 + SeedsPerSecond.GetHashCode();
+                hash = hash * 31 + SeedsPerMeter.GetHashCode();
+                hash = hash * 31 + SingulationPercent.GetHashCode();
+                hash = hash * 31 + DoublesPercent.GetHashCode();
+                hash = hash * 31 + SkipsPercent.GetHashCode();
+                hash = hash * 31 + MeterRpm.GetHashCode();
+                hash = hash * 31 + Timestamp.GetHashCode();
+                return hash;
+            }
+        }
+
+        public static bool operator ==(RowMetric left, RowMetric right) => left.Equals(right);
+        public static bool operator !=(RowMetric left, RowMetric right) => !left.Equals(right);
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding/SeedingMonitor.cs
+++ b/SourceCode/AgOpenGPS.Seeding/SeedingMonitor.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace AgOpenGPS.Seeding
+{
+    public sealed class SeedingMonitor
+    {
+        private readonly List<PlanterRow> _rows;
+        private SeedingSnapshot? _lastSnapshot;
+
+        public SeedingMonitor(IEnumerable<PlanterRow> rows, SeedingTargets targets)
+        {
+            if (rows is null) throw new ArgumentNullException(nameof(rows));
+            _rows = new List<PlanterRow>(rows);
+            Rows = new ReadOnlyCollection<PlanterRow>(_rows);
+            Targets = targets ?? throw new ArgumentNullException(nameof(targets));
+        }
+
+        public IReadOnlyList<PlanterRow> Rows { get; }
+        public SeedingTargets Targets { get; }
+        public SeedingSnapshot? LastSnapshot => _lastSnapshot;
+
+        public event EventHandler<SeedingSnapshot>? SnapshotPublished;
+        public event EventHandler<RowAlert>? AlertRaised;
+
+        public void Bind(ISeedingDataSource source)
+        {
+            if (source is null) throw new ArgumentNullException(nameof(source));
+            source.SnapshotReceived += OnSnapshot;
+            source.AlertReceived += OnAlert;
+        }
+
+        public void Unbind(ISeedingDataSource source)
+        {
+            if (source is null) return;
+            source.SnapshotReceived -= OnSnapshot;
+            source.AlertReceived -= OnAlert;
+        }
+
+        private void OnSnapshot(object? sender, SeedingSnapshot snapshot)
+        {
+            _lastSnapshot = snapshot;
+            SnapshotPublished?.Invoke(this, snapshot);
+        }
+
+        private void OnAlert(object? sender, RowAlert alert)
+        {
+            AlertRaised?.Invoke(this, alert);
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding/SeedingSnapshot.cs
+++ b/SourceCode/AgOpenGPS.Seeding/SeedingSnapshot.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace AgOpenGPS.Seeding
+{
+    public sealed class SeedingSnapshot
+    {
+        public SeedingSnapshot(
+            IReadOnlyList<RowMetric>? rows,
+            double targetSeedsPerMeter,
+            double averageSeedsPerMeter,
+            double variationPercent,
+            double meterShaftRpm,
+            double hectaresWorked,
+            double speedKmh,
+            DateTimeOffset timestamp)
+        {
+            Rows = rows ?? Array.Empty<RowMetric>();
+            TargetSeedsPerMeter = targetSeedsPerMeter;
+            AverageSeedsPerMeter = averageSeedsPerMeter;
+            VariationPercent = variationPercent;
+            MeterShaftRpm = meterShaftRpm;
+            HectaresWorked = hectaresWorked;
+            SpeedKmh = speedKmh;
+            Timestamp = timestamp;
+        }
+
+        public IReadOnlyList<RowMetric> Rows { get; }
+        public double TargetSeedsPerMeter { get; }
+        public double AverageSeedsPerMeter { get; }
+        public double VariationPercent { get; }
+        public double MeterShaftRpm { get; }
+        public double HectaresWorked { get; }
+        public double SpeedKmh { get; }
+        public DateTimeOffset Timestamp { get; }
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding/SeedingTargets.cs
+++ b/SourceCode/AgOpenGPS.Seeding/SeedingTargets.cs
@@ -1,0 +1,26 @@
+namespace AgOpenGPS.Seeding
+{
+    public sealed class SeedingTargets
+    {
+        public SeedingTargets(double targetSeedsPerHectare, double rowSpacingCm, double boomWidthMeters)
+        {
+            TargetSeedsPerHectare = targetSeedsPerHectare;
+            RowSpacingCm = rowSpacingCm;
+            BoomWidthMeters = boomWidthMeters;
+        }
+
+        public double TargetSeedsPerHectare { get; set; }
+        public double RowSpacingCm { get; set; }
+        public double BoomWidthMeters { get; set; }
+
+        public double TargetSeedsPerMeterPerRow
+        {
+            get
+            {
+                if (RowSpacingCm <= 0) return 0;
+                double rowSpacingM = RowSpacingCm / 100.0;
+                return TargetSeedsPerHectare * rowSpacingM / 10000.0;
+            }
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding/Sources/CanBusSeedingDataSource.cs
+++ b/SourceCode/AgOpenGPS.Seeding/Sources/CanBusSeedingDataSource.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AgOpenGPS.Seeding.Sources
+{
+    // Stub. Future: read PGN frames from AgIO via an injected ICanBusFrameReader and
+    // translate them into RowMetric/RowAlert events. ISO 11783 TC-SC compatible target.
+    public sealed class CanBusSeedingDataSource : ISeedingDataSource
+    {
+        public CanBusSeedingDataSource(int rowCount)
+        {
+            if (rowCount <= 0) throw new ArgumentOutOfRangeException(nameof(rowCount));
+            RowCount = rowCount;
+        }
+
+        public event EventHandler<SeedingSnapshot>? SnapshotReceived;
+        public event EventHandler<RowAlert>? AlertReceived;
+
+        public int RowCount { get; }
+
+        public bool IsRunning { get; private set; }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            IsRunning = true;
+            // No real frames yet. Hardware integration lands in a follow-up phase.
+            _ = SnapshotReceived;
+            _ = AlertReceived;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync()
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Seeding/Sources/SimulatedSeedingDataSource.cs
+++ b/SourceCode/AgOpenGPS.Seeding/Sources/SimulatedSeedingDataSource.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AgOpenGPS.Seeding.Sources
+{
+    public sealed class SimulatedSeedingDataSource : ISeedingDataSource, IDisposable
+    {
+        private readonly Random _rng;
+        private readonly SeedingTargets _targets;
+        private readonly TimeSpan _samplePeriod;
+        private readonly double _doubleSeedProbability;
+        private readonly double _skipProbability;
+
+        private CancellationTokenSource? _cts;
+        private Task? _loop;
+        private double _hectaresAccumulator;
+        private double _meterRpm = 35.0;
+
+        public SimulatedSeedingDataSource(
+            int rowCount = 24,
+            SeedingTargets? targets = null,
+            int sampleHz = 10,
+            double doubleSeedProbability = 0.005,
+            double skipProbability = 0.005,
+            int? randomSeed = null)
+        {
+            if (rowCount <= 0) throw new ArgumentOutOfRangeException(nameof(rowCount));
+            if (sampleHz <= 0) throw new ArgumentOutOfRangeException(nameof(sampleHz));
+
+            RowCount = rowCount;
+            _targets = targets ?? new SeedingTargets(targetSeedsPerHectare: 80000, rowSpacingCm: 52.5, boomWidthMeters: rowCount * 0.525);
+            _samplePeriod = TimeSpan.FromMilliseconds(1000.0 / sampleHz);
+            _doubleSeedProbability = doubleSeedProbability;
+            _skipProbability = skipProbability;
+            _rng = randomSeed.HasValue ? new Random(randomSeed.Value) : new Random();
+        }
+
+        public event EventHandler<SeedingSnapshot>? SnapshotReceived;
+        public event EventHandler<RowAlert>? AlertReceived;
+
+        public int RowCount { get; }
+
+        public bool IsRunning => _loop is { IsCompleted: false };
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (IsRunning) return Task.CompletedTask;
+
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _loop = Task.Run(() => RunLoopAsync(_cts.Token), _cts.Token);
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync()
+        {
+            if (_cts is null) return;
+            try { _cts.Cancel(); } catch (ObjectDisposedException) { }
+            try
+            {
+                if (_loop is not null) await _loop.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { }
+            _cts.Dispose();
+            _cts = null;
+            _loop = null;
+        }
+
+        public void Dispose()
+        {
+            try { StopAsync().GetAwaiter().GetResult(); }
+            catch { /* best effort */ }
+        }
+
+        private async Task RunLoopAsync(CancellationToken token)
+        {
+            double speedKmh = 7.5;
+            double targetPerMeter = _targets.TargetSeedsPerMeterPerRow > 0 ? _targets.TargetSeedsPerMeterPerRow : 5.2;
+
+            while (!token.IsCancellationRequested)
+            {
+                speedKmh = Clamp(speedKmh + (_rng.NextDouble() - 0.5) * 0.4, 5.0, 11.0);
+                double speedMs = speedKmh / 3.6;
+                _meterRpm = Clamp(_meterRpm + (_rng.NextDouble() - 0.5) * 1.5, 25.0, 55.0);
+
+                double dt = _samplePeriod.TotalSeconds;
+                double swathArea = _targets.BoomWidthMeters * speedMs * dt;
+                _hectaresAccumulator += swathArea / 10000.0;
+
+                var rows = new List<RowMetric>(RowCount);
+                double sumPerMeter = 0;
+                var now = DateTimeOffset.UtcNow;
+
+                for (int i = 0; i < RowCount; i++)
+                {
+                    double jitter = (_rng.NextDouble() - 0.5) * 0.6;
+                    double seedsPerMeter = Math.Max(0, targetPerMeter + jitter);
+                    double seedsPerSecond = seedsPerMeter * speedMs;
+
+                    double doubles = _rng.NextDouble() < _doubleSeedProbability ? _rng.NextDouble() * 8 : _rng.NextDouble() * 1.2;
+                    double skips = _rng.NextDouble() < _skipProbability ? _rng.NextDouble() * 6 : _rng.NextDouble() * 0.8;
+                    double singulation = Math.Max(0, 100 - doubles - skips);
+
+                    rows.Add(new RowMetric(
+                        rowIndex: i,
+                        seedsPerSecond: seedsPerSecond,
+                        seedsPerMeter: seedsPerMeter,
+                        singulationPercent: singulation,
+                        doublesPercent: doubles,
+                        skipsPercent: skips,
+                        meterRpm: _meterRpm,
+                        timestamp: now));
+                    sumPerMeter += seedsPerMeter;
+
+                    if (doubles > 5)
+                    {
+                        AlertReceived?.Invoke(this, new RowAlert(i, RowAlertSeverity.Warning, RowAlertCode.DoubleSeed,
+                            $"Semilla doble alta en surco {i + 1}", now));
+                    }
+                    else if (skips > 4)
+                    {
+                        AlertReceived?.Invoke(this, new RowAlert(i, RowAlertSeverity.Critical, RowAlertCode.NoFlow,
+                            $"Falla de flujo en surco {i + 1}", now));
+                    }
+                }
+
+                double avg = rows.Count > 0 ? sumPerMeter / rows.Count : 0;
+                double variation = avg > 0 ? (avg - targetPerMeter) / targetPerMeter * 100.0 : 0;
+
+                var snapshot = new SeedingSnapshot(
+                    rows: rows,
+                    targetSeedsPerMeter: targetPerMeter,
+                    averageSeedsPerMeter: avg,
+                    variationPercent: variation,
+                    meterShaftRpm: _meterRpm,
+                    hectaresWorked: _hectaresAccumulator,
+                    speedKmh: speedKmh,
+                    timestamp: now);
+
+                SnapshotReceived?.Invoke(this, snapshot);
+
+                try { await Task.Delay(_samplePeriod, token).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+
+        private static double Clamp(double v, double min, double max) => v < min ? min : (v > max ? max : v);
+    }
+}

--- a/SourceCode/AgOpenGPS.sln
+++ b/SourceCode/AgOpenGPS.sln
@@ -35,6 +35,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgDiag", "AgDiag\AgDiag.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.Tests", "AgOpenGPS.Tests\AgOpenGPS.Tests.csproj", "{9715B97C-C1F8-C513-91D4-2D00A94334D4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.Seeding", "AgOpenGPS.Seeding\AgOpenGPS.Seeding.csproj", "{7E3D1A9F-2B4C-4D5E-9F1A-3C2B1D4E5F60}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.AvaloniaApp", "AgOpenGPS.AvaloniaApp\AgOpenGPS.AvaloniaApp.csproj", "{8F4E2BA0-3C5D-4E6F-A02B-4D3C2E5F6071}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +97,14 @@ Global
 		{9715B97C-C1F8-C513-91D4-2D00A94334D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9715B97C-C1F8-C513-91D4-2D00A94334D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9715B97C-C1F8-C513-91D4-2D00A94334D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E3D1A9F-2B4C-4D5E-9F1A-3C2B1D4E5F60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E3D1A9F-2B4C-4D5E-9F1A-3C2B1D4E5F60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E3D1A9F-2B4C-4D5E-9F1A-3C2B1D4E5F60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E3D1A9F-2B4C-4D5E-9F1A-3C2B1D4E5F60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F4E2BA0-3C5D-4E6F-A02B-4D3C2E5F6071}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F4E2BA0-3C5D-4E6F-A02B-4D3C2E5F6071}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F4E2BA0-3C5D-4E6F-A02B-4D3C2E5F6071}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F4E2BA0-3C5D-4E6F-A02B-4D3C2E5F6071}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SourceCode/AgOpenGPS.sln
+++ b/SourceCode/AgOpenGPS.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.Seeding", "AgOpen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.AvaloniaApp", "AgOpenGPS.AvaloniaApp\AgOpenGPS.AvaloniaApp.csproj", "{8F4E2BA0-3C5D-4E6F-A02B-4D3C2E5F6071}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.Seeding.Tests", "AgOpenGPS.Seeding.Tests\AgOpenGPS.Seeding.Tests.csproj", "{9C5F4E1B-4D7A-4F6E-B12C-5E4D3F6A7082}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -105,6 +107,10 @@ Global
 		{8F4E2BA0-3C5D-4E6F-A02B-4D3C2E5F6071}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8F4E2BA0-3C5D-4E6F-A02B-4D3C2E5F6071}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8F4E2BA0-3C5D-4E6F-A02B-4D3C2E5F6071}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C5F4E1B-4D7A-4F6E-B12C-5E4D3F6A7082}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C5F4E1B-4D7A-4F6E-B12C-5E4D3F6A7082}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C5F4E1B-4D7A-4F6E-B12C-5E4D3F6A7082}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C5F4E1B-4D7A-4F6E-B12C-5E4D3F6A7082}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/avalonia-dashboard-mockup.svg
+++ b/docs/avalonia-dashboard-mockup.svg
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1672 940" width="1672" height="940" font-family="Inter, 'Segoe UI', Roboto, sans-serif">
+  <!-- ============================================================
+       Visual mockup of the AgOpenGPS.AvaloniaApp Dashboard layout.
+       Mirrors DashboardView.axaml: outer margin 12, Grid rows
+       (80 | * | 52 | 80) and columns (240 | * | 320).
+       Palette comes from Themes/Colors.axaml. Branding "CentriX"
+       is the default in Config/branding.json.
+       ============================================================ -->
+  <defs>
+    <linearGradient id="viewportSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0a1f0d"/>
+      <stop offset="1" stop-color="#050b07"/>
+    </linearGradient>
+    <linearGradient id="fieldGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3a1108"/>
+      <stop offset="1" stop-color="#1c0804"/>
+    </linearGradient>
+    <linearGradient id="coverageGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#404045"/>
+      <stop offset="1" stop-color="#1f1f22"/>
+    </linearGradient>
+  </defs>
+
+  <!-- BackgroundColor #0E0E0E -->
+  <rect width="1672" height="940" fill="#0E0E0E"/>
+
+  <!-- =================== HEADER BAR (Row 0) =================== -->
+  <!-- x=12..1660 y=12..92, surface card -->
+  <rect x="12" y="12" width="1648" height="80" rx="8" fill="#1A1A1A"/>
+
+  <!-- Brand: PilotName (CentriX) + Tagline -->
+  <text x="32" y="46" fill="#FFFFFF" font-size="22" font-weight="600">CentriX</text>
+  <text x="32" y="68" fill="#4CD964" font-size="10" letter-spacing="2">PRECISION SEEDING CO-PILOT</text>
+
+  <!-- 4 KPI tiles centered in header -->
+  <!-- tile width 160, spacing 14, total 4*160 + 3*14 = 682. Centered around x=836 → starts x=495 -->
+  <!-- TILE 1: VELOCIDAD -->
+  <rect x="495" y="22" width="160" height="60" rx="10" fill="#1A1A1A" stroke="#222222" stroke-width="1"/>
+  <text x="509" y="40" fill="#9A9A9A" font-size="11" letter-spacing="1">VELOCIDAD</text>
+  <text x="509" y="68" fill="#FFFFFF" font-size="26" font-weight="700">7.8</text>
+  <text x="565" y="68" fill="#9A9A9A" font-size="12">km/h</text>
+
+  <!-- TILE 2: RPM -->
+  <rect x="669" y="22" width="160" height="60" rx="10" fill="#1A1A1A" stroke="#222222" stroke-width="1"/>
+  <text x="683" y="40" fill="#9A9A9A" font-size="11" letter-spacing="1">RPM</text>
+  <text x="683" y="68" fill="#FFFFFF" font-size="26" font-weight="700">1550</text>
+  <text x="755" y="68" fill="#9A9A9A" font-size="12">rpm</text>
+
+  <!-- TILE 3: GPS -->
+  <rect x="843" y="22" width="160" height="60" rx="10" fill="#1A1A1A" stroke="#222222" stroke-width="1"/>
+  <text x="857" y="40" fill="#9A9A9A" font-size="11" letter-spacing="1">GPS</text>
+  <text x="975" y="40" fill="#4CD964" font-size="11" letter-spacing="1">FIX</text>
+  <text x="857" y="68" fill="#FFFFFF" font-size="26" font-weight="700">RTK</text>
+
+  <!-- TILE 4: HECTAREAS -->
+  <rect x="1017" y="22" width="160" height="60" rx="10" fill="#1A1A1A" stroke="#222222" stroke-width="1"/>
+  <text x="1031" y="40" fill="#9A9A9A" font-size="11" letter-spacing="1">HECTAREAS</text>
+  <text x="1031" y="68" fill="#FFFFFF" font-size="26" font-weight="700">23.6</text>
+  <text x="1099" y="68" fill="#9A9A9A" font-size="12">ha</text>
+
+  <!-- =================== LEFT: POR SURCO (Row 1, Col 0) =================== -->
+  <!-- Cell x=12..252 (w=240), Margin 0,12,12,0 → x=12..240, y=104..796 -->
+  <rect x="12" y="104" width="228" height="692" rx="8" fill="#1A1A1A"/>
+  <text x="26" y="130" fill="#9A9A9A" font-size="11" font-weight="600" letter-spacing="2">POR SURCO</text>
+
+  <!-- Column headers -->
+  <text x="26" y="158" fill="#9A9A9A" font-size="11" letter-spacing="1">SURCO</text>
+  <text x="100" y="158" fill="#9A9A9A" font-size="11" letter-spacing="1">SEM/M</text>
+  <text x="200" y="158" fill="#9A9A9A" font-size="11" letter-spacing="1" text-anchor="end">ESTADO</text>
+
+  <!-- 24 row entries. Mostly green, a couple warning, one critical. -->
+  <!-- Each row ~22 px high. -->
+  <g font-size="13" fill="#FFFFFF">
+    <!-- 1 -->
+    <text x="36" y="184">1</text>   <text x="100" y="184">5.2</text>  <circle cx="208" cy="180" r="5" fill="#4CD964"/>
+    <text x="36" y="206">2</text>   <text x="100" y="206">5.1</text>  <circle cx="208" cy="202" r="5" fill="#4CD964"/>
+    <text x="36" y="228">3</text>   <text x="100" y="228">5.3</text>  <circle cx="208" cy="224" r="5" fill="#4CD964"/>
+    <text x="36" y="250">4</text>   <text x="100" y="250">5.2</text>  <circle cx="208" cy="246" r="5" fill="#4CD964"/>
+    <text x="36" y="272">5</text>   <text x="100" y="272">5.0</text>  <circle cx="208" cy="268" r="5" fill="#4CD964"/>
+    <text x="36" y="294">6</text>   <text x="100" y="294">4.8</text>  <circle cx="208" cy="290" r="5" fill="#FF9500"/>
+    <text x="36" y="316" fill="#FF3B30">7</text>   <text x="100" y="316" fill="#FF3B30">0.0</text>  <circle cx="208" cy="312" r="5" fill="#FF3B30"/>
+    <text x="36" y="338">8</text>   <text x="100" y="338">5.4</text>  <circle cx="208" cy="334" r="5" fill="#4CD964"/>
+    <text x="36" y="360">9</text>   <text x="100" y="360">5.1</text>  <circle cx="208" cy="356" r="5" fill="#4CD964"/>
+    <text x="36" y="382">10</text>  <text x="100" y="382">5.2</text>  <circle cx="208" cy="378" r="5" fill="#4CD964"/>
+    <text x="36" y="404">11</text>  <text x="100" y="404">5.3</text>  <circle cx="208" cy="400" r="5" fill="#4CD964"/>
+    <text x="36" y="426">12</text>  <text x="100" y="426">5.1</text>  <circle cx="208" cy="422" r="5" fill="#4CD964"/>
+    <text x="36" y="448">13</text>  <text x="100" y="448">5.0</text>  <circle cx="208" cy="444" r="5" fill="#4CD964"/>
+    <text x="36" y="470">14</text>  <text x="100" y="470">5.2</text>  <circle cx="208" cy="466" r="5" fill="#4CD964"/>
+    <text x="36" y="492">15</text>  <text x="100" y="492">5.3</text>  <circle cx="208" cy="488" r="5" fill="#4CD964"/>
+    <text x="36" y="514">16</text>  <text x="100" y="514">4.9</text>  <circle cx="208" cy="510" r="5" fill="#FF9500"/>
+    <text x="36" y="536">17</text>  <text x="100" y="536">5.2</text>  <circle cx="208" cy="532" r="5" fill="#4CD964"/>
+    <text x="36" y="558">18</text>  <text x="100" y="558">5.1</text>  <circle cx="208" cy="554" r="5" fill="#4CD964"/>
+    <text x="36" y="580">19</text>  <text x="100" y="580">5.3</text>  <circle cx="208" cy="576" r="5" fill="#4CD964"/>
+    <text x="36" y="602">20</text>  <text x="100" y="602">5.2</text>  <circle cx="208" cy="598" r="5" fill="#4CD964"/>
+    <text x="36" y="624">21</text>  <text x="100" y="624">5.1</text>  <circle cx="208" cy="620" r="5" fill="#4CD964"/>
+    <text x="36" y="646">22</text>  <text x="100" y="646">5.2</text>  <circle cx="208" cy="642" r="5" fill="#4CD964"/>
+    <text x="36" y="668">23</text>  <text x="100" y="668">5.3</text>  <circle cx="208" cy="664" r="5" fill="#4CD964"/>
+    <text x="36" y="690">24</text>  <text x="100" y="690">5.1</text>  <circle cx="208" cy="686" r="5" fill="#4CD964"/>
+  </g>
+
+  <!-- Footer of left panel: Dosis actual -->
+  <line x1="26" y1="710" x2="216" y2="710" stroke="#2A2A2A" stroke-width="1"/>
+  <text x="26" y="734" fill="#9A9A9A" font-size="11" letter-spacing="1">DOSIS ACTUAL</text>
+  <text x="26" y="770" fill="#FFFFFF" font-size="26" font-weight="700">5.2</text>
+  <text x="80" y="770" fill="#9A9A9A" font-size="12">sem/m</text>
+
+  <!-- =================== CENTER VIEWPORT (Row 1, Col 1) =================== -->
+  <!-- Cell x=252..1340 (w=1088). Margin 0,12,0,0 → x=252..1340, y=104..796 (h=692) -->
+  <rect x="252" y="104" width="1088" height="692" rx="8" fill="url(#viewportSky)"/>
+
+  <!-- Field perspective: tractor lane converging to vanishing point -->
+  <g transform="translate(252,104)">
+    <!-- Worked field area (red/brown) -->
+    <polygon points="0,692 1088,692 700,140 388,140" fill="url(#fieldGrad)" opacity="0.85"/>
+    <!-- Coverage swath already done (gray) -->
+    <polygon points="0,692 388,692 388,140 280,140" fill="url(#coverageGrad)" opacity="0.55"/>
+    <!-- Guidance lines -->
+    <g stroke="#1f7a2a" stroke-width="1" opacity="0.7">
+      <line x1="120" y1="692" x2="430" y2="140"/>
+      <line x1="240" y1="692" x2="478" y2="140"/>
+      <line x1="360" y1="692" x2="525" y2="140"/>
+      <line x1="480" y1="692" x2="572" y2="140"/>
+      <line x1="600" y1="692" x2="619" y2="140"/>
+      <line x1="720" y1="692" x2="666" y2="140"/>
+      <line x1="840" y1="692" x2="713" y2="140"/>
+      <line x1="960" y1="692" x2="760" y2="140"/>
+    </g>
+    <!-- Active centerline -->
+    <line x1="544" y1="692" x2="544" y2="140" stroke="#bcbcc0" stroke-width="2"/>
+    <!-- Headland marker top -->
+    <line x1="370" y1="140" x2="720" y2="140" stroke="#3aa6f5" stroke-width="2" opacity="0.7"/>
+    <!-- Tractor + implement -->
+    <g transform="translate(544, 540)">
+      <rect x="-60" y="-6" width="120" height="12" fill="#FF3B30"/>
+      <circle cx="-60" cy="0" r="4" fill="#4CD964"/>
+      <circle cx="-30" cy="0" r="4" fill="#4CD964"/>
+      <circle cx="0"   cy="0" r="4" fill="#4CD964"/>
+      <circle cx="30"  cy="0" r="4" fill="#4CD964"/>
+      <circle cx="60"  cy="0" r="4" fill="#4CD964"/>
+      <rect x="-12" y="6" width="24" height="36" fill="#0a0a0a" stroke="#FF3B30" stroke-width="1"/>
+      <text x="0" y="-14" fill="#FFFFFF" font-size="14" text-anchor="middle">↑ 1L</text>
+    </g>
+    <!-- Distance indicator -->
+    <text x="820" y="220" fill="#FFFFFF" font-size="13">242 m →</text>
+    <!-- Top HUD numbers -->
+    <text x="544" y="36" fill="#FFFFFF" font-size="22" font-weight="700" text-anchor="middle">▶ 0 ◀</text>
+    <text x="20"  y="36" fill="#FFFFFF" font-size="12">8.3 cm</text>
+    <text x="1068" y="36" fill="#FFFFFF" font-size="12" text-anchor="end">13.8</text>
+  </g>
+
+  <!-- =================== RIGHT: CONTROL (Row 1, Col 2) =================== -->
+  <!-- Cell x=1340..1660 (w=320). Margin 12,12,0,0 → x=1352..1660 (w=308), y=104..796 -->
+  <rect x="1352" y="104" width="308" height="692" rx="8" fill="#1A1A1A"/>
+  <text x="1370" y="130" fill="#9A9A9A" font-size="11" font-weight="600" letter-spacing="2">CONTROL</text>
+
+  <!-- Densidad objetivo -->
+  <text x="1370" y="166" fill="#9A9A9A" font-size="11" letter-spacing="1">DENSIDAD OBJETIVO</text>
+  <text x="1370" y="200" fill="#FFFFFF" font-size="26" font-weight="700">5.2</text>
+  <text x="1424" y="200" fill="#9A9A9A" font-size="12">sem/m</text>
+
+  <!-- Variacion -->
+  <text x="1370" y="240" fill="#9A9A9A" font-size="11" letter-spacing="1">VARIACION</text>
+  <text x="1370" y="266" fill="#4CD964" font-size="20" font-weight="600">+1.8 %</text>
+
+  <!-- Corte por seccion -->
+  <text x="1370" y="304" fill="#9A9A9A" font-size="11" letter-spacing="1">CORTE POR SECCION</text>
+  <g transform="translate(1370,318)">
+    <rect x="0"   y="0" width="22" height="22" rx="4" fill="#4CD964"/>
+    <rect x="26"  y="0" width="22" height="22" rx="4" fill="#4CD964"/>
+    <rect x="52"  y="0" width="22" height="22" rx="4" fill="#4CD964"/>
+    <rect x="78"  y="0" width="22" height="22" rx="4" fill="#4CD964"/>
+    <rect x="104" y="0" width="22" height="22" rx="4" fill="#3a3a3a"/>
+    <rect x="130" y="0" width="22" height="22" rx="4" fill="#3a3a3a"/>
+    <rect x="156" y="0" width="22" height="22" rx="4" fill="#3a3a3a"/>
+    <rect x="182" y="0" width="22" height="22" rx="4" fill="#3a3a3a"/>
+  </g>
+
+  <!-- Estado dosificador -->
+  <text x="1370" y="386" fill="#9A9A9A" font-size="11" letter-spacing="1">ESTADO DOSIFICADOR</text>
+  <text x="1370" y="412" fill="#4CD964" font-size="16" font-weight="600">OK ✓</text>
+
+  <!-- Linea actual -->
+  <text x="1370" y="450" fill="#9A9A9A" font-size="11" letter-spacing="1">LINEA ACTUAL</text>
+  <text x="1370" y="476" fill="#FFFFFF" font-size="16" font-weight="600">1 L</text>
+  <rect x="1560" y="458" width="80" height="26" rx="6" fill="#222222" stroke="#2A2A2A"/>
+  <text x="1600" y="476" fill="#FFFFFF" font-size="11" text-anchor="middle">Cambiar línea</text>
+
+  <!-- Superposicion -->
+  <text x="1370" y="514" fill="#9A9A9A" font-size="11" letter-spacing="1">SUPERPOSICION</text>
+  <text x="1370" y="544" fill="#FFFFFF" font-size="26" font-weight="700">2.3</text>
+  <text x="1424" y="544" fill="#9A9A9A" font-size="12">cm</text>
+  <!-- mini histogram -->
+  <g transform="translate(1370,560)" fill="#4CD964">
+    <rect x="0"   y="14" width="6" height="16"/>
+    <rect x="9"   y="10" width="6" height="20"/>
+    <rect x="18"  y="6"  width="6" height="24"/>
+    <rect x="27"  y="2"  width="6" height="28"/>
+    <rect x="36"  y="8"  width="6" height="22"/>
+    <rect x="45"  y="12" width="6" height="18"/>
+    <rect x="54"  y="6"  width="6" height="24"/>
+    <rect x="63"  y="3"  width="6" height="27"/>
+    <rect x="72"  y="0"  width="6" height="30"/>
+    <rect x="81"  y="4"  width="6" height="26"/>
+    <rect x="90"  y="9"  width="6" height="21"/>
+    <rect x="99"  y="14" width="6" height="16"/>
+    <rect x="108" y="11" width="6" height="19"/>
+    <rect x="117" y="6"  width="6" height="24"/>
+    <rect x="126" y="9"  width="6" height="21"/>
+    <rect x="135" y="14" width="6" height="16"/>
+    <rect x="144" y="18" width="6" height="12"/>
+  </g>
+
+  <!-- =================== ROW 2: BOTTOM ALERTS =================== -->
+  <!-- Cell y=796..848 (h=52), Margin 0,12,0,0 → y=808..848 (h=40), x=12..1660 -->
+  <rect x="12" y="808" width="1648" height="40" rx="8" fill="#1A1A1A"/>
+  <text x="32" y="833" fill="#9A9A9A" font-size="11" font-weight="600" letter-spacing="2">ALERTAS</text>
+
+  <!-- Alert cards -->
+  <g transform="translate(110,816)">
+    <!-- critical -->
+    <rect x="0" y="0" width="220" height="24" rx="6" fill="#3A1414"/>
+    <circle cx="14" cy="12" r="6" fill="#FF3B30"/>
+    <text x="28" y="16" fill="#FFFFFF" font-size="12" font-weight="700">Surco 7</text>
+    <text x="78" y="16" fill="#9A9A9A" font-size="11">FALLA EN SURCO</text>
+
+    <!-- warning -->
+    <rect x="232" y="0" width="220" height="24" rx="6" fill="#3A2A0F"/>
+    <circle cx="246" cy="12" r="6" fill="#FF9500"/>
+    <text x="260" y="16" fill="#FFFFFF" font-size="12" font-weight="700">Surco 6</text>
+    <text x="310" y="16" fill="#9A9A9A" font-size="11">BAJA DENSIDAD</text>
+
+    <!-- warning -->
+    <rect x="464" y="0" width="240" height="24" rx="6" fill="#3A2A0F"/>
+    <circle cx="478" cy="12" r="6" fill="#FF9500"/>
+    <text x="492" y="16" fill="#FFFFFF" font-size="12" font-weight="700">Semilla doble</text>
+    <text x="572" y="16" fill="#9A9A9A" font-size="11">DETECTADA</text>
+
+    <!-- warning -->
+    <rect x="716" y="0" width="220" height="24" rx="6" fill="#3A2A0F"/>
+    <circle cx="730" cy="12" r="6" fill="#FF9500"/>
+    <text x="744" y="16" fill="#FFFFFF" font-size="12" font-weight="700">Velocidad</text>
+    <text x="810" y="16" fill="#9A9A9A" font-size="11">FUERA DE RANGO</text>
+  </g>
+
+  <text x="1640" y="833" fill="#9A9A9A" font-size="11" text-anchor="end">VER HISTORIAL ›</text>
+
+  <!-- =================== ROW 3: BOTTOM TOOLBAR =================== -->
+  <!-- Cell y=848..928 (h=80), Margin 0,12,0,0 → y=860..928 (h=68), x=12..1660 -->
+  <rect x="12" y="860" width="1648" height="68" rx="8" fill="#1A1A1A"/>
+
+  <!-- Centered cluster of toolbar buttons -->
+  <g font-size="12" font-weight="600" fill="#FFFFFF">
+    <!-- SECCIONES AUTO (toggle, on → accent) -->
+    <rect x="540" y="876" width="160" height="36" rx="10" fill="#4CD964"/>
+    <text x="620" y="899" text-anchor="middle" fill="#0E0E0E">SECCIONES AUTO</text>
+
+    <!-- previous AB -->
+    <rect x="710" y="876" width="60" height="36" rx="10" fill="#222222"/>
+    <text x="740" y="899" text-anchor="middle">| AB</text>
+
+    <!-- PLAY (toggle, off) -->
+    <rect x="780" y="876" width="100" height="36" rx="10" fill="#222222"/>
+    <text x="830" y="899" text-anchor="middle">▶ PLAY</text>
+
+    <!-- next AB -->
+    <rect x="890" y="876" width="60" height="36" rx="10" fill="#222222"/>
+    <text x="920" y="899" text-anchor="middle">AB ▶</text>
+
+    <!-- AUTOSTEER (toggle, off) -->
+    <rect x="960" y="876" width="140" height="36" rx="10" fill="#222222"/>
+    <text x="1030" y="899" text-anchor="middle">AUTOSTEER</text>
+  </g>
+
+</svg>


### PR DESCRIPTION
Introduces a netstandard2.0 project that models per-row planter telemetry —
PlanterRow, RowMetric, RowAlert, SeedingTargets, SeedingSnapshot —
together with a SeedingMonitor aggregate, an ISeedingDataSource contract,
and two implementations: SimulatedSeedingDataSource (10 Hz development feed
with realistic jitter and occasional warning/critical alerts) and a
CanBusSeedingDataSource stub for future hardware integration.

Kept as a standalone project rather than added to AgOpenGPS.Core to avoid
inheriting Core's PresentationCore (WPF) dependency, which would prevent
cross-platform consumers (Avalonia) from referencing it.

https://claude.ai/code/session_01Lgw4LiC4q3ktaRuEQgfVmw